### PR TITLE
fix(ci): pull_request_target による脆弱性に対応

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,11 +25,60 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.merged == true && github.base_ref || github.event.pull_request.head.sha }}
+  # pull_request と pull_request_target が同一グループになると互いをキャンセルしてしまうため
+  # event_name を含めることで両イベントのキャンセルを独立させる
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  post-approval-request:
+    name: Post approval request
+    runs-on: ubuntu-latest
+    # フォーク PR のときのみ承認リクエストを投稿する（closed は不要）
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'closed'
+    continue-on-error: true
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Find existing approval request comment
+        id: find-comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: Environment 承認待ち
+
+      - name: Post or update approval request comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            ## Environment 承認待ち
+
+            この PR のビルドを実行するには、Environment `fork-pr-build` の承認が必要です。
+
+            [Actions run を確認して承認してください](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
+
+  approval-gate:
+    name: Approval gate
+    runs-on: ubuntu-latest
+    needs: post-approval-request
+    # post-approval-request の結果に関わらず常に実行する
+    if: always()
+    # フォーク PR かつ closed でない場合のみ Environment で手動承認が必要
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'closed' && 'fork-pr-build' || '' }}
+    permissions: {}
+    steps:
+      - name: Approval granted
+        run: echo "Approval gate passed"
+
   docker-ci:
     name: Docker CI
+    needs: approval-gate
+    if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
     uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-


### PR DESCRIPTION
## 概要

`pull_request_target` トリガーを使用したワークフローで、フォーク PR の HEAD SHA をチェックアウトして Docker ビルドを実行していたため、悪意のある PR によって `GITHUB_TOKEN`（書き込み権限）や secrets が漏洩するリスクがありました。

`post-approval-request` ジョブと `approval-gate` 中間ジョブを追加することで、フォーク PR のビルドを手動承認が通過するまでブロックするようにしました。

## 変更内容

- `concurrency` グループを `event_name` を含む形式に更新（`pull_request` と `pull_request_target` の二重発火によるキャンセル問題を防止）
- `post-approval-request` ジョブを追加（フォーク PR 時に承認待ちコメントを投稿）
- `approval-gate` ジョブを追加（フォーク PR の場合のみ `fork-pr-build` Environment で手動承認を要求）
- `docker-ci` ジョブに `needs: approval-gate` と `if` 条件を追加

## fork-pr-build Environment について

`fork-pr-build` Environment は gh API により作成済みです（必須レビュアー: book000）。

## 参考

- [pull_request_target 脆弱性対応 汎用改修設計](https://gist.github.com/akubiusa/9fb82b1c204cce1d52a7d4f9443cb5ad)