### PR TITLE
fix(crawler): 存在しないブックマークを DELETE すると 500 エラーになる問題を修正

### DIFF
--- a/crawler/src/infra/bookmarks-api.ts
+++ b/crawler/src/infra/bookmarks-api.ts
@@ -266,10 +266,12 @@ export async function addBookmark(
  * 指定ツイートをブックマークから削除する。
  * PostApiUtils のラッパーには未実装のため、内部の generated PostApi を直接呼び出す。
  * ブックマークが存在しない場合は冪等な削除として正常終了する。
+ * それ以外のエラー（ネットワークエラー、レート制限等）は呼び出し元に再スローする。
  *
  * @param client TwitterOpenApi クライアント
  * @param tweetId ツイート ID
  * @throws DeleteBookmark フラグが存在しない、または queryId が不正な場合
+ * @throws ブックマーク不存在以外のエラー（ネットワークエラー、レート制限等）
  */
 export async function removeBookmark(
   client: TwitterOpenApiClient,
@@ -292,10 +294,10 @@ export async function removeBookmark(
     )
   }
   const queryId = flagEntry.queryId
-  try {
-    await withRetry(
-      () =>
-        postApiUtils.api.postDeleteBookmark(
+  await withRetry(
+    async () => {
+      try {
+        return await postApiUtils.api.postDeleteBookmark(
           {
             pathQueryId: queryId,
             postDeleteBookmarkRequest: {
@@ -304,21 +306,25 @@ export async function removeBookmark(
             },
           },
           postApiUtils.initOverrides(flagEntry)
-        ),
-      { operationName: `removeBookmark(${tweetId})` }
-    )
-  } catch (error) {
-    // twitter-openapi-typescript は存在しないブックマークを削除しようとすると
-    // レスポンスの特定フィールドが undefined になり TypeError が発生する。
-    // ブックマークが既に存在しない（冪等な削除）として無視する。
-    if (
-      error instanceof TypeError &&
-      error.message.includes('Cannot read properties of undefined')
-    ) {
-      return
-    }
-    throw error
-  }
+        )
+      } catch (error) {
+        // twitter-openapi-typescript は存在しないブックマークを削除しようとすると
+        // レスポンスの .map() 呼び出しで TypeError が発生する。
+        // このケースはブックマークが既に存在しない（冪等な削除）として無視し、
+        // withRetry によるリトライをスキップする。
+        if (
+          error instanceof TypeError &&
+          error.message.includes(
+            "Cannot read properties of undefined (reading 'map')"
+          )
+        ) {
+          return
+        }
+        throw error
+      }
+    },
+    { operationName: `removeBookmark(${tweetId})` }
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

`DELETE /bookmarks/:tweetId` で Twitter 側に対象ブックマークが存在しない場合に 500 エラーが返る問題を修正します。

## 変更内容

### 原因

`twitter-openapi-typescript` の `postDeleteBookmark` は、ブックマークが存在しない場合に Twitter API レスポンスの特定フィールドが `undefined` になり、内部で `.map()` を呼び出す際に `TypeError: Cannot read properties of undefined (reading 'map')` が発生していた。

### 修正方法

`removeBookmark` 関数の `withRetry` コールバック内で `TypeError` をキャッチし、以下のように処理するよう変更：

- `TypeError` かつメッセージが `"Cannot read properties of undefined (reading 'map')"` に一致する場合 → ブックマークが既に存在しない（冪等な削除）として正常終了。`withRetry` によるリトライをスキップする
- それ以外のエラー → 従来通り rethrow（ネットワークエラー、レート制限等は `withRetry` がリトライ）

### コードレビューによる改善点（commit c8c2b98）

- **TypeError を withRetry 内で処理**: 外側の try/catch では不存在ブックマーク削除時に最大 3 回リトライ（約 14 秒）が走っていた問題を解消
- **エラーメッセージマッチを精緻化**: `"Cannot read properties of undefined"` から `"Cannot read properties of undefined (reading 'map')"` に絞り込み、無関係な TypeError の誤検知リスクを低減
- **JSDoc 補完**: `@throws` に抑制される TypeError と再スローされるエラーを明記

### 変更ファイル

- `crawler/src/infra/bookmarks-api.ts` — `removeBookmark` の TypeError ハンドリングを withRetry コールバック内に移動

## テスト方法

```bash
# 存在しないツイート ID に対して DELETE リクエストを送る
curl -X DELETE "http://localhost:3001/bookmarks/9999999999999999999?account=<username>"
# 修正前: 500 {"error": "Failed to delete bookmark: Cannot read properties of undefined (reading 'map')"}
# 修正後: 200 {"message": "Bookmark deleted."}
```

- Closes #13