### PR TITLE
feat(viewer): スマホ UI 改善とブックマーク解除機能を追加

### DIFF
--- a/crawler/Dockerfile
+++ b/crawler/Dockerfile
@@ -20,13 +20,17 @@ COPY viewer/frontend/package.json ./viewer/frontend/
 COPY viewer/backend/package.json ./viewer/backend/
 
 # ロックファイルからパッケージをストアにフェッチ（ネットワーク層をキャッシュ）
-RUN --mount=type=cache,id=pnpm-crawler,target=/pnpm/store pnpm fetch
+# viewer と同一の pnpm-store キャッシュを共有し、重複ダウンロードを防ぐ
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm fetch
 
 # shared パッケージのソースをコピー（workspace リンクに必要）
 COPY shared/ ./shared/
 
 # crawler の全依存パッケージをインストール（ネイティブモジュールをここでコンパイル）
-RUN --mount=type=cache,id=pnpm-crawler,target=/pnpm/store pnpm install --offline --frozen-lockfile --filter twitter-bookmark-hub-crawler
+# node-gyp キャッシュを共有して better-sqlite3 の再コンパイルを防ぐ
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    --mount=type=cache,id=node-gyp,target=/root/.cache/node-gyp \
+    pnpm install --offline --frozen-lockfile --filter twitter-bookmark-hub-crawler
 
 # crawler のソースをコピー
 COPY crawler/ ./crawler/

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -23,13 +23,17 @@ COPY viewer/frontend/package.json ./viewer/frontend/
 COPY viewer/backend/package.json ./viewer/backend/
 
 # ロックファイルからパッケージをストアにフェッチ（ネットワーク層をキャッシュ）
-RUN --mount=type=cache,id=pnpm-frontend,target=/pnpm/store pnpm fetch
+# crawler/backend と同一の pnpm-store キャッシュを共有し、重複ダウンロードを防ぐ
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm fetch
 
 # shared パッケージのソースをコピー（workspace リンクに必要）
 COPY shared/ ./shared/
 
 # frontend の全依存パッケージをインストール
-RUN --mount=type=cache,id=pnpm-frontend,target=/pnpm/store pnpm install --offline --frozen-lockfile --filter twitter-bookmark-hub-frontend
+# node-gyp キャッシュを共有してネイティブモジュールの再コンパイルを防ぐ
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    --mount=type=cache,id=node-gyp,target=/root/.cache/node-gyp \
+    pnpm install --offline --frozen-lockfile --filter twitter-bookmark-hub-frontend
 
 # frontend のソースをコピーしてビルド
 COPY viewer/frontend/ ./viewer/frontend/
@@ -57,13 +61,17 @@ COPY viewer/frontend/package.json ./viewer/frontend/
 COPY viewer/backend/package.json ./viewer/backend/
 
 # ロックファイルからパッケージをストアにフェッチ（ネットワーク層をキャッシュ）
-RUN --mount=type=cache,id=pnpm-backend,target=/pnpm/store pnpm fetch
+# frontend と同一の pnpm-store キャッシュを共有し、重複ダウンロードを防ぐ
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm fetch
 
 # shared パッケージのソースをコピー（workspace リンクに必要）
 COPY shared/ ./shared/
 
 # backend の全依存パッケージをインストール（ネイティブモジュールをここでコンパイル）
-RUN --mount=type=cache,id=pnpm-backend,target=/pnpm/store pnpm install --offline --frozen-lockfile --filter twitter-bookmark-hub-backend
+# node-gyp キャッシュを共有して better-sqlite3 の再コンパイルを防ぐ
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    --mount=type=cache,id=node-gyp,target=/root/.cache/node-gyp \
+    pnpm install --offline --frozen-lockfile --filter twitter-bookmark-hub-backend
 
 # backend のソースとフロントエンドのビルド成果物をコピー
 COPY viewer/backend/ ./viewer/backend/

--- a/viewer/backend/src/routes/bookmarks.ts
+++ b/viewer/backend/src/routes/bookmarks.ts
@@ -3,9 +3,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type Database from 'better-sqlite3'
 import { getBookmarks } from '../infra/database'
 import type { BookmarksResponse } from '../shared/types'
-
-/** クローラーサービスの URL */
-const CRAWLER_URL = process.env.CRAWLER_URL ?? 'http://crawler:3001'
+import { CRAWLER_URL } from '../shared/config'
 
 /**
  * ブックマーク API ルートを作成する

--- a/viewer/backend/src/routes/bookmarks.ts
+++ b/viewer/backend/src/routes/bookmarks.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type Database from 'better-sqlite3'
 import { getBookmarks } from '../infra/database'
 import type { BookmarksResponse } from '../shared/types'
+
+/** クローラーサービスの URL */
+const CRAWLER_URL = process.env.CRAWLER_URL ?? 'http://crawler:3001'
 
 /**
  * ブックマーク API ルートを作成する
@@ -62,6 +66,43 @@ export function bookmarksRoute(db: Database.Database): Hono {
     }
 
     return c.json(response)
+  })
+
+  /** DELETE /api/bookmarks/:tweetId - ブックマークを解除する（クローラーに転送） */
+  app.delete('/api/bookmarks/:tweetId', async (c) => {
+    const tweetId = c.req.param('tweetId')
+    const account = c.req.query('account')
+    if (!account) {
+      return c.json({ error: 'account query parameter is required.' }, 400)
+    }
+
+    // 30 秒でタイムアウトし、ハングした接続でリクエストがブロックされるのを防ぐ
+    const controller = new AbortController()
+    const timer = setTimeout(() => {
+      controller.abort()
+    }, 30_000)
+    try {
+      const url = new URL(
+        `${CRAWLER_URL}/bookmarks/${encodeURIComponent(tweetId)}`
+      )
+      url.searchParams.set('account', account)
+      const res = await fetch(url.toString(), {
+        method: 'DELETE',
+        signal: controller.signal,
+      })
+      const contentType = res.headers.get('content-type') ?? ''
+      const data: unknown = contentType.includes('application/json')
+        ? await res.json()
+        : { message: await res.text() }
+      return c.json(data, res.status as ContentfulStatusCode)
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return c.json({ error: 'Crawler service timed out.' }, 504)
+      }
+      return c.json({ error: 'Crawler service is unavailable.' }, 502)
+    } finally {
+      clearTimeout(timer)
+    }
   })
 
   return app

--- a/viewer/backend/src/routes/crawl.ts
+++ b/viewer/backend/src/routes/crawl.ts
@@ -2,9 +2,7 @@ import { Hono } from 'hono'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type Database from 'better-sqlite3'
 import { getLatestCrawlJob } from '../infra/database'
-
-/** クローラーサービスの URL */
-const CRAWLER_URL = process.env.CRAWLER_URL ?? 'http://crawler:3001'
+import { CRAWLER_URL } from '../shared/config'
 
 /**
  * クロール API ルートを作成する

--- a/viewer/backend/src/shared/config.ts
+++ b/viewer/backend/src/shared/config.ts
@@ -1,0 +1,2 @@
+/** クローラーサービスの URL（環境変数 CRAWLER_URL で上書き可能） */
+export const CRAWLER_URL = process.env.CRAWLER_URL ?? 'http://crawler:3001'

--- a/viewer/frontend/eslint.config.mjs
+++ b/viewer/frontend/eslint.config.mjs
@@ -46,6 +46,8 @@ export default [
       // unicorn は null より undefined を好むが、Vue の v-model や Optional Chaining と
       // の相性を考慮して .vue ファイルに限り無効化する
       'unicorn/no-null': 'off',
+      // .ts/.tsx 同様に省略形を許可する（unicorn flat/recommended が .vue にも適用されるため明示的に無効化）
+      'unicorn/prevent-abbreviations': 'off',
       // vue-eslint-parser が生成する仮想ファイルには型情報が不完全なため、
       // TypeScript の unsafe 系ルールを .vue ファイルに限り無効化する
       // @see https://github.com/vuejs/vue-eslint-parser/issues/104

--- a/viewer/frontend/index.html
+++ b/viewer/frontend/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- video.twimg.com のホットリンク保護を回避するために Referer を送らないよう指示する -->
     <meta name="referrer" content="no-referrer" />
+    <meta name="description" content="複数の Twitter/X アカウントのブックマークを自動収集して一元閲覧できるビューア" />
     <!-- PWA 設定 -->
     <meta name="theme-color" content="#1d9bf0" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/viewer/frontend/src/App.vue
+++ b/viewer/frontend/src/App.vue
@@ -300,6 +300,8 @@ function onBookmarkDeleted(payload: { tweetId: string; account: string }) {
   --color-accent-hover: #1a8cd8;
   --color-success: #00ba7c;
   --color-error: #f4212e;
+  --color-error-bg: rgba(244, 33, 46, 0.1);
+  --header-height: 53px;
 }
 
 /* キーボードフォーカスの視覚的フィードバック（マウス操作では表示しない） */
@@ -458,8 +460,8 @@ body {
   flex-shrink: 0;
   border-right: 1px solid var(--color-border);
   position: sticky;
-  top: 53px;
-  height: calc(100vh - 53px);
+  top: var(--header-height);
+  height: calc(100vh - var(--header-height));
   overflow-y: auto;
   overflow-x: hidden;
   transition:
@@ -623,9 +625,9 @@ body {
   .sidebar {
     position: fixed;
     inset: 0;
-    top: 53px;
+    top: var(--header-height);
     width: 100% !important;
-    height: calc(100vh - 53px) !important;
+    height: calc(100vh - var(--header-height)) !important;
     z-index: 20;
     border-right: none;
     border-bottom: none;
@@ -643,7 +645,7 @@ body {
     pointer-events: none;
     /* width/height はオーバーライドされているため 0 への縮小は不要 */
     width: 100% !important;
-    height: calc(100vh - 53px) !important;
+    height: calc(100vh - var(--header-height)) !important;
     border-bottom-color: transparent;
   }
 
@@ -651,7 +653,7 @@ body {
   .sidebar-overlay {
     position: fixed;
     inset: 0;
-    top: 53px;
+    top: var(--header-height);
     z-index: 19;
     background: rgba(0, 0, 0, 0.5);
   }

--- a/viewer/frontend/src/App.vue
+++ b/viewer/frontend/src/App.vue
@@ -23,6 +23,7 @@ const {
   hasMore,
   loadMore,
   toggleSortOrder,
+  removeItemAccount,
 } = useBookmarks()
 
 const { accounts } = useAccounts()
@@ -157,6 +158,14 @@ function onTagClick(tag: string) {
 function clearTagFilter() {
   globalThis.location.hash = '#/'
 }
+
+/**
+ * ブックマーク解除完了時に items からアカウントを削除する。
+ * @param payload - 解除されたツイート ID とアカウント名
+ */
+function onBookmarkDeleted(payload: { tweetId: string; account: string }) {
+  removeItemAccount(payload.tweetId, payload.account)
+}
 </script>
 
 <template>
@@ -186,7 +195,13 @@ function clearTagFilter() {
           class="nav-btn"
           :class="{ active: currentView === 'settings' }"
           @click="navigateTo(currentView === 'settings' ? 'main' : 'settings')">
-          {{ currentView === 'settings' ? '← 戻る' : '⚙ 設定' }}
+          <!-- PC: テキスト表示 / スマホ: アイコンのみ表示 -->
+          <span class="nav-btn-label">{{
+            currentView === 'settings' ? '← 戻る' : '⚙ 設定'
+          }}</span>
+          <span class="nav-btn-icon" aria-hidden="true">{{
+            currentView === 'settings' ? '←' : '⚙'
+          }}</span>
         </button>
       </div>
     </header>
@@ -196,6 +211,12 @@ function clearTagFilter() {
 
     <!-- メインページ -->
     <div v-else class="layout">
+      <!-- スマホ: サイドバー展開時のオーバーレイ背景 -->
+      <div
+        v-if="sidebarOpen"
+        class="sidebar-overlay"
+        aria-hidden="true"
+        @click="sidebarOpen = false" />
       <!-- サイドバー -->
       <aside class="sidebar" :class="{ 'sidebar-closed': !sidebarOpen }">
         <AccountFilter
@@ -256,7 +277,8 @@ function clearTagFilter() {
           :error="error"
           :has-more="hasMore"
           @load-more="loadMore"
-          @tag-click="onTagClick" />
+          @tag-click="onTagClick"
+          @bookmark-deleted="onBookmarkDeleted" />
       </main>
     </div>
   </div>
@@ -348,6 +370,21 @@ body {
 .nav-btn.active {
   border-color: var(--color-accent);
   color: var(--color-accent);
+}
+
+/* PC ではアイコンを非表示にして、スマホではテキストを非表示にする */
+.nav-btn-icon {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .nav-btn-label {
+    display: none;
+  }
+
+  .nav-btn-icon {
+    display: inline;
+  }
 }
 
 /* サイドバー開閉ボタン */
@@ -560,18 +597,41 @@ body {
     flex-direction: column;
   }
 
+  /* スマホ: サイドバーを全画面オーバーレイとして表示する */
   .sidebar {
-    width: 100%;
-    position: static;
-    height: auto;
+    position: fixed;
+    inset: 0;
+    top: 53px;
+    width: 100% !important;
+    height: calc(100vh - 53px) !important;
+    z-index: 20;
     border-right: none;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: none;
+    overflow-y: auto;
+    background: var(--color-bg);
+    transition:
+      opacity 0.25s ease,
+      visibility 0.25s ease;
+    visibility: visible;
   }
 
   .sidebar.sidebar-closed {
-    width: 100%;
-    height: 0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    /* width/height はオーバーライドされているため 0 への縮小は不要 */
+    width: 100% !important;
+    height: calc(100vh - 53px) !important;
     border-bottom-color: transparent;
+  }
+
+  /* スマホ: オーバーレイ背景（サイドバーの後ろを暗くする） */
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    top: 53px;
+    z-index: 19;
+    background: rgba(0, 0, 0, 0.5);
   }
 
   .main {

--- a/viewer/frontend/src/App.vue
+++ b/viewer/frontend/src/App.vue
@@ -177,6 +177,8 @@ function onBookmarkDeleted(payload: { tweetId: string; account: string }) {
         <button
           class="sidebar-toggle"
           :title="sidebarOpen ? 'サイドバーを閉じる' : 'サイドバーを開く'"
+          :aria-label="sidebarOpen ? 'サイドバーを閉じる' : 'サイドバーを開く'"
+          :aria-expanded="sidebarOpen"
           :class="{ 'is-open': sidebarOpen }"
           @click="sidebarOpen = !sidebarOpen">
           <span class="hamburger-line" />
@@ -293,9 +295,17 @@ function onBookmarkDeleted(payload: { tweetId: string; account: string }) {
   --color-bg-hover: #080808;
   --color-border: #2f3336;
   --color-text-primary: #e7e9ea;
-  --color-text-secondary: #71767b;
+  --color-text-secondary: #8b9098;
   --color-accent: #1d9bf0;
   --color-accent-hover: #1a8cd8;
+  --color-success: #00ba7c;
+  --color-error: #f4212e;
+}
+
+/* キーボードフォーカスの視覚的フィードバック（マウス操作では表示しない） */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 * {
@@ -590,6 +600,17 @@ body {
 
 .filter-chip-clear:hover {
   background: rgba(29, 155, 240, 0.2);
+}
+
+/* アニメーション軽減設定 */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 /* レスポンシブ */

--- a/viewer/frontend/src/App.vue
+++ b/viewer/frontend/src/App.vue
@@ -194,6 +194,7 @@ function onBookmarkDeleted(payload: { tweetId: string; account: string }) {
           v-if="analyzerEnabled"
           class="nav-btn"
           :class="{ active: currentView === 'settings' }"
+          :aria-label="currentView === 'settings' ? '戻る' : '設定'"
           @click="navigateTo(currentView === 'settings' ? 'main' : 'settings')">
           <!-- PC: テキスト表示 / スマホ: アイコンのみ表示 -->
           <span class="nav-btn-label">{{

--- a/viewer/frontend/src/api.ts
+++ b/viewer/frontend/src/api.ts
@@ -179,6 +179,23 @@ export async function deleteCategory(id: number): Promise<void> {
 }
 
 /**
+ * ブックマークを解除する。クローラー経由で Twitter 側からも削除する
+ * @param tweetId - ツイート ID
+ * @param account - 解除対象のアカウント名
+ */
+export async function deleteBookmark(
+  tweetId: string,
+  account: string
+): Promise<void> {
+  const query = new URLSearchParams({ account })
+  const res = await fetch(
+    `${BASE}/bookmarks/${encodeURIComponent(tweetId)}?${query.toString()}`,
+    { method: 'DELETE' }
+  )
+  if (!res.ok) return throwResponseError(res, 'Failed to delete bookmark')
+}
+
+/**
  * 頻出タグ一覧を取得する
  * @param limit - 上限件数（デフォルト 50）
  * @returns タグアイテムの配列

--- a/viewer/frontend/src/components/AccountFilter.vue
+++ b/viewer/frontend/src/components/AccountFilter.vue
@@ -24,7 +24,7 @@ function select(username: string | null) {
 
 <template>
   <div class="account-filter">
-    <h3 class="filter-title">アカウント</h3>
+    <h2 class="filter-title">アカウント</h2>
     <ul class="account-list">
       <li
         class="account-item"

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -332,14 +332,14 @@ const deletingAccounts = ref(new Set<string>())
  * @param account - 解除対象のアカウント名
  */
 async function onDeleteBookmark(account: string) {
-  if (!confirm(`@${account} のブックマークを解除しますか？`)) return
+  if (!confirm(`Remove bookmark for @${account}?`)) return
   deletingAccounts.value = new Set([...deletingAccounts.value, account])
   try {
     await deleteBookmark(properties.item.tweetId, account)
     emit('bookmark-deleted', { tweetId: properties.item.tweetId, account })
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
-    alert(`ブックマーク解除に失敗しました: ${message}`)
+    alert(`Failed to remove bookmark: ${message}`)
   } finally {
     const next = new Set(deletingAccounts.value)
     next.delete(account)

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -672,6 +672,7 @@ async function onDeleteBookmark(account: string) {
               class="bookmark-delete-btn"
               :disabled="deletingAccounts.has(account)"
               :title="`@${account} のブックマークを解除`"
+              :aria-label="`@${account} のブックマークを解除`"
               @click.stop="onDeleteBookmark(account)">
               <svg
                 viewBox="0 0 24 24"

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -351,6 +351,8 @@ async function onDeleteBookmark(account: string) {
 <template>
   <article
     class="tweet"
+    role="article"
+    :aria-label="`${item.userName} (@${item.screenName}) のツイート`"
     tabindex="0"
     @click="onCardClick"
     @keydown="onCardKeydown">
@@ -382,7 +384,9 @@ async function onDeleteBookmark(account: string) {
           <span class="meta-right">
             <span class="screen-name">@{{ item.screenName }}</span>
             <span class="meta-sep" aria-hidden="true">·</span>
-            <time class="tweet-time">{{ relativeTime }}</time>
+            <time class="tweet-time" :datetime="item.createdAt">{{
+              relativeTime
+            }}</time>
           </span>
         </div>
         <!-- ヘッダー右: 外部リンクボタン -->
@@ -912,10 +916,6 @@ async function onDeleteBookmark(account: string) {
 
 .text-link {
   color: var(--color-accent);
-  text-decoration: none;
-}
-
-.text-link:hover {
   text-decoration: underline;
 }
 
@@ -1257,7 +1257,7 @@ async function onDeleteBookmark(account: string) {
 
 .bookmark-delete-btn:hover:not(:disabled) {
   background: rgba(244, 33, 46, 0.1);
-  color: #f4212e;
+  color: var(--color-error);
 }
 
 .bookmark-delete-btn:disabled {

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -1256,7 +1256,7 @@ async function onDeleteBookmark(account: string) {
 }
 
 .bookmark-delete-btn:hover:not(:disabled) {
-  background: rgba(244, 33, 46, 0.1);
+  background: var(--color-error-bg);
   color: var(--color-error);
 }
 

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { BookmarkItem, UrlEntity } from '../api'
+import { deleteBookmark } from '../api'
 
 /** タッチデバイス判定 */
 const isTouchDevice =
@@ -15,6 +16,8 @@ const properties = defineProps<{
 const emit = defineEmits<{
   /** タグをクリックしたときに発火する */
   'tag-click': [tag: string]
+  /** ブックマーク解除が完了したときに発火する */
+  'bookmark-deleted': [{ tweetId: string; account: string }]
 }>()
 
 // ---- アバター ---------------------------------------------------------------
@@ -317,6 +320,32 @@ function upgradedImageUrl(
 const twitterAppUrl = computed(
   () => `twitter://status?id=${properties.item.tweetId}`
 )
+
+// ---- ブックマーク解除 --------------------------------------------------------
+
+/** 解除処理中のアカウント名セット */
+const deletingAccounts = ref(new Set<string>())
+
+/**
+ * 指定アカウントのブックマークを解除する。
+ * 確認ダイアログを表示し、承諾された場合のみ API を呼び出す。
+ * @param account - 解除対象のアカウント名
+ */
+async function onDeleteBookmark(account: string) {
+  if (!confirm(`@${account} のブックマークを解除しますか？`)) return
+  deletingAccounts.value = new Set([...deletingAccounts.value, account])
+  try {
+    await deleteBookmark(properties.item.tweetId, account)
+    emit('bookmark-deleted', { tweetId: properties.item.tweetId, account })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    alert(`ブックマーク解除に失敗しました: ${message}`)
+  } finally {
+    const next = new Set(deletingAccounts.value)
+    next.delete(account)
+    deletingAccounts.value = next
+  }
+}
 </script>
 
 <template>
@@ -626,7 +655,7 @@ const twitterAppUrl = computed(
         </button>
       </div>
 
-      <!-- フッター: ブックマーク済みアカウント -->
+      <!-- フッター: ブックマーク済みアカウント + 解除ボタン -->
       <div class="tweet-footer">
         <div class="bookmarked-by">
           <svg viewBox="0 0 24 24" class="bookmark-icon" aria-hidden="true">
@@ -637,9 +666,31 @@ const twitterAppUrl = computed(
           <span
             v-for="account in item.bookmarkedBy"
             :key="account"
-            class="bookmark-account"
-            >@{{ account }}</span
-          >
+            class="bookmark-account-group">
+            <span class="bookmark-account">@{{ account }}</span>
+            <button
+              class="bookmark-delete-btn"
+              :disabled="deletingAccounts.has(account)"
+              :title="`@${account} のブックマークを解除`"
+              @click.stop="onDeleteBookmark(account)">
+              <svg
+                viewBox="0 0 24 24"
+                class="bookmark-delete-icon"
+                aria-hidden="true">
+                <path
+                  d="M6 2a2 2 0 0 0-2 2v17.586l8-4 8 4V4a2 2 0 0 0-2-2H6zm0 2h12v14.414l-6-3-6 3V4z"
+                  fill="currentColor" />
+                <line
+                  x1="4"
+                  y1="4"
+                  x2="20"
+                  y2="20"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linecap="round" />
+              </svg>
+            </button>
+          </span>
         </div>
       </div>
     </div>
@@ -1173,9 +1224,49 @@ const twitterAppUrl = computed(
   flex-shrink: 0;
 }
 
+.bookmark-account-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .bookmark-account {
   font-size: 13px;
   color: var(--color-text-secondary);
+}
+
+/* ブックマーク解除ボタン */
+.bookmark-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0;
+  transition:
+    background 0.15s,
+    color 0.15s;
+  flex-shrink: 0;
+}
+
+.bookmark-delete-btn:hover:not(:disabled) {
+  background: rgba(244, 33, 46, 0.1);
+  color: #f4212e;
+}
+
+.bookmark-delete-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.bookmark-delete-icon {
+  width: 14px;
+  height: 14px;
 }
 
 /* ============================================================

--- a/viewer/frontend/src/components/BookmarkList.vue
+++ b/viewer/frontend/src/components/BookmarkList.vue
@@ -19,6 +19,8 @@ const emit = defineEmits<{
   'load-more': []
   /** タグがクリックされた */
   'tag-click': [tag: string]
+  /** ブックマーク解除が完了した */
+  'bookmark-deleted': [{ tweetId: string; account: string }]
 }>()
 
 /** センチネル要素（スクロール末端の検知用） */
@@ -77,7 +79,8 @@ onUnmounted(() => {
         v-for="item in items"
         :key="item.tweetId"
         :item="item"
-        @tag-click="(tag) => emit('tag-click', tag)" />
+        @tag-click="(tag) => emit('tag-click', tag)"
+        @bookmark-deleted="(payload) => emit('bookmark-deleted', payload)" />
     </template>
 
     <!-- 無限スクロール用センチネル + 追加読み込みインジケータ -->

--- a/viewer/frontend/src/components/CategoryFilter.vue
+++ b/viewer/frontend/src/components/CategoryFilter.vue
@@ -24,7 +24,7 @@ function select(id: number | null) {
 
 <template>
   <div class="category-filter">
-    <h3 class="filter-title">カテゴリ</h3>
+    <h2 class="filter-title">カテゴリ</h2>
     <ul class="category-list">
       <li
         class="category-item"

--- a/viewer/frontend/src/components/CrawlStatus.vue
+++ b/viewer/frontend/src/components/CrawlStatus.vue
@@ -49,6 +49,7 @@ function relativeTime(dateString: string): string {
     <button
       class="crawl-button"
       :disabled="triggering || status?.status === 'running'"
+      aria-label="クロール実行"
       @click="triggerCrawl">
       <!-- PC: テキスト表示 / スマホ: アイコンのみ表示 -->
       <svg viewBox="0 0 24 24" class="crawl-icon" aria-hidden="true">

--- a/viewer/frontend/src/components/CrawlStatus.vue
+++ b/viewer/frontend/src/components/CrawlStatus.vue
@@ -50,7 +50,13 @@ function relativeTime(dateString: string): string {
       class="crawl-button"
       :disabled="triggering || status?.status === 'running'"
       @click="triggerCrawl">
-      クロール実行
+      <!-- PC: テキスト表示 / スマホ: アイコンのみ表示 -->
+      <svg viewBox="0 0 24 24" class="crawl-icon" aria-hidden="true">
+        <path
+          d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+          fill="currentColor" />
+      </svg>
+      <span class="crawl-btn-label">クロール実行</span>
     </button>
   </div>
 </template>
@@ -60,6 +66,30 @@ function relativeTime(dateString: string): string {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.crawl-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  /* PC ではアイコンを非表示 */
+  display: none;
+}
+
+/* スマホではアイコンを表示し、テキストを非表示にする */
+@media (max-width: 768px) {
+  .crawl-icon {
+    display: block;
+  }
+
+  .crawl-btn-label {
+    display: none;
+  }
+
+  /* アイコンのみになるため正方形に近いパディングに変更 */
+  .crawl-button {
+    padding: 7px 10px;
+  }
 }
 
 .status-info {
@@ -108,6 +138,9 @@ function relativeTime(dateString: string): string {
 }
 
 .crawl-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   background: var(--color-accent);
   color: #fff;
   border: none;
@@ -116,6 +149,7 @@ function relativeTime(dateString: string): string {
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;
+  white-space: nowrap;
   transition: background 0.2s;
 }
 

--- a/viewer/frontend/src/components/CrawlStatus.vue
+++ b/viewer/frontend/src/components/CrawlStatus.vue
@@ -112,11 +112,11 @@ function relativeTime(dateString: string): string {
 }
 
 .status-dot.success {
-  background: #00ba7c;
+  background: var(--color-success);
 }
 
 .status-dot.error {
-  background: #f4212e;
+  background: var(--color-error);
 }
 
 @keyframes pulse {
@@ -135,7 +135,7 @@ function relativeTime(dateString: string): string {
 }
 
 .error-text {
-  color: #f4212e;
+  color: var(--color-error);
 }
 
 .crawl-button {

--- a/viewer/frontend/src/composables/useBookmarks.ts
+++ b/viewer/frontend/src/composables/useBookmarks.ts
@@ -1,4 +1,4 @@
-import { ref, watch, watchEffect } from 'vue'
+import { ref, watch, watchEffect, onScopeDispose } from 'vue'
 import { fetchBookmarks } from '../api'
 import type { BookmarkItem } from '../api'
 
@@ -7,15 +7,26 @@ import type { BookmarkItem } from '../api'
  * 前回の呼び出しから delay ms 経過するまで実行を遅延する。
  * @param fn - デバウンス対象の関数
  * @param delay - 遅延時間（ミリ秒）
+ * @returns デバウンスされた関数と、保留中タイマーをキャンセルする cancel 関数
  */
-function debounce<T extends () => void>(fn: T, delay: number): T {
+function debounce<T extends () => void>(
+  fn: T,
+  delay: number
+): { fn: T; cancel: () => void } {
   let timer: ReturnType<typeof setTimeout> | null = null
-  return function (this: unknown) {
+  const debouncedFn = function (this: unknown) {
     if (timer !== null) clearTimeout(timer)
     timer = setTimeout(() => {
       fn.call(this)
     }, delay)
   } as T
+  const cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+  return { fn: debouncedFn, cancel }
 }
 
 /** localStorage のキー定数 */
@@ -56,10 +67,12 @@ export function useBookmarks() {
   })
 
   /** 検索クエリ変更時に 200ms デバウンスして debouncedSearchQuery を更新する */
-  const updateDebouncedQuery = debounce(() => {
+  const { fn: updateDebouncedQuery, cancel: cancelDebounce } = debounce(() => {
     debouncedSearchQuery.value = searchQuery.value
   }, 200)
   watch(searchQuery, updateDebouncedQuery)
+  // スコープ破棄時に保留中タイマーをキャンセルして不要な state 更新を防ぐ
+  onScopeDispose(cancelDebounce)
 
   /** 蓄積されたブックマーク一覧（無限スクロールで追記） */
   const items = ref<BookmarkItem[]>([])

--- a/viewer/frontend/src/composables/useBookmarks.ts
+++ b/viewer/frontend/src/composables/useBookmarks.ts
@@ -160,6 +160,16 @@ export function useBookmarks() {
     if (idx === -1) return
     const item = items.value[idx]
     const newBookmarkedBy = item.bookmarkedBy.filter((a) => a !== account)
+
+    // アカウントフィルタ中に、そのアカウントのブックマークを解除した場合は
+    // newBookmarkedBy に他アカウントが残っていても現在の一覧からは除去する。
+    // フィルタ済みリストにはそのアカウントがブックマークしたツイートのみが含まれるため。
+    if (selectedAccount.value === account) {
+      items.value = items.value.filter((_, i) => i !== idx)
+      total.value = Math.max(0, total.value - 1)
+      return
+    }
+
     if (newBookmarkedBy.length === 0) {
       items.value = items.value.filter((_, i) => i !== idx)
       total.value = Math.max(0, total.value - 1)

--- a/viewer/frontend/src/composables/useBookmarks.ts
+++ b/viewer/frontend/src/composables/useBookmarks.ts
@@ -2,6 +2,22 @@ import { ref, watch, watchEffect } from 'vue'
 import { fetchBookmarks } from '../api'
 import type { BookmarkItem } from '../api'
 
+/**
+ * 指定した関数を delay ミリ秒デバウンスするユーティリティ。
+ * 前回の呼び出しから delay ms 経過するまで実行を遅延する。
+ * @param fn - デバウンス対象の関数
+ * @param delay - 遅延時間（ミリ秒）
+ */
+function debounce<T extends () => void>(fn: T, delay: number): T {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  return function (this: unknown) {
+    if (timer !== null) clearTimeout(timer)
+    timer = setTimeout(() => {
+      fn.call(this)
+    }, delay)
+  } as T
+}
+
 /** localStorage のキー定数 */
 const LS_SORT_BY = 'bookmark-sort-by'
 const LS_SORT_ORDER = 'bookmark-sort-order'
@@ -17,6 +33,8 @@ export function useBookmarks() {
   const selectedCategory = ref<number | null>(null)
   const selectedTag = ref<string | null>(null)
   const searchQuery = ref('')
+  /** 検索クエリのデバウンス済み値（200ms 遅延）。watchEffect はこちらを追跡する */
+  const debouncedSearchQuery = ref('')
 
   /** ソートキー（localStorage から復元） */
   const rawSortBy = localStorage.getItem(LS_SORT_BY)
@@ -36,6 +54,12 @@ export function useBookmarks() {
   watch(sortOrder, (val) => {
     localStorage.setItem(LS_SORT_ORDER, val)
   })
+
+  /** 検索クエリ変更時に 200ms デバウンスして debouncedSearchQuery を更新する */
+  const updateDebouncedQuery = debounce(() => {
+    debouncedSearchQuery.value = searchQuery.value
+  }, 200)
+  watch(searchQuery, updateDebouncedQuery)
 
   /** 蓄積されたブックマーク一覧（無限スクロールで追記） */
   const items = ref<BookmarkItem[]>([])
@@ -66,7 +90,7 @@ export function useBookmarks() {
       limit: limit.value,
       sort: sortOrder.value,
       sortBy: sortBy.value,
-      ...(searchQuery.value ? { q: searchQuery.value } : {}),
+      ...(debouncedSearchQuery.value ? { q: debouncedSearchQuery.value } : {}),
       ...(selectedAccount.value ? { account: selectedAccount.value } : {}),
       ...(selectedCategory.value === null
         ? {}

--- a/viewer/frontend/src/composables/useBookmarks.ts
+++ b/viewer/frontend/src/composables/useBookmarks.ts
@@ -149,6 +149,27 @@ export function useBookmarks() {
     sortOrder.value = sortOrder.value === 'desc' ? 'asc' : 'desc'
   }
 
+  /**
+   * ローカルの items から指定アカウントのブックマークを削除する。
+   * bookmarkedBy が空になった場合はアイテム自体も除去する。
+   * @param tweetId - ツイート ID
+   * @param account - 解除したアカウント名
+   */
+  function removeItemAccount(tweetId: string, account: string) {
+    const idx = items.value.findIndex((item) => item.tweetId === tweetId)
+    if (idx === -1) return
+    const item = items.value[idx]
+    const newBookmarkedBy = item.bookmarkedBy.filter((a) => a !== account)
+    if (newBookmarkedBy.length === 0) {
+      items.value = items.value.filter((_, i) => i !== idx)
+      total.value = Math.max(0, total.value - 1)
+    } else {
+      items.value = items.value.map((it, i) =>
+        i === idx ? { ...it, bookmarkedBy: newBookmarkedBy } : it
+      )
+    }
+  }
+
   return {
     page,
     limit,
@@ -165,5 +186,6 @@ export function useBookmarks() {
     hasMore,
     loadMore,
     toggleSortOrder,
+    removeItemAccount,
   }
 }


### PR DESCRIPTION
## 概要

Issues #18・#19・#20 を対応し、外部レビュー指摘事項の対応も含めた変更です。

## 変更内容

### Issue #18 — スマホでヘッダーボタンをアイコン化

- **ナビゲーションボタン**（設定/戻る）: スマホでアイコンのみ表示、PC ではテキスト表示
  - `<span class="nav-btn-label">` と `<span class="nav-btn-icon">` の 2 要素構成
  - `:aria-label` で視覚的に非表示でもスクリーンリーダーに伝わるよう対応
- **クロール実行ボタン**: スマホで SVG リフレッシュアイコンのみ表示、PC ではテキスト表示

### Issue #19 — スマホでサイドバーを全画面オーバーレイ表示

- スマホ時に `position: fixed; inset: 0; top: 53px` でビューポート全体を覆うように変更
- 幅/高さの折りたたみアニメーションを `opacity + visibility` のフェードトランジションに変更
- オーバーレイ背景（`sidebar-overlay`）を追加し、クリックで閉じられるよう実装
- z-index 管理: サイドバーは 20、オーバーレイ背景は 19

### Issue #20 — ブックマーク解除ボタンの追加

- **viewer/backend**: `DELETE /api/bookmarks/:tweetId` エンドポイントを追加（crawler へのプロキシ）
  - `account` クエリパラメータ必須、30 秒タイムアウト、エラー時は 502/504 を返す
- **viewer/frontend `api.ts`**: `deleteBookmark(tweetId, account)` 関数を追加
- **`useBookmarks.ts`**: `removeItemAccount(tweetId, account)` を追加
  - アカウントフィルタ中に解除した場合は他アカウントのブックマークが残っていても一覧から除去
  - `bookmarkedBy` が空になった場合もアイテム全体を除去
- **`BookmarkCard.vue`**: 各アカウントのブックマーク表示の隣に解除ボタンを追加
  - 確認ダイアログ表示 → API 呼び出し → `bookmark-deleted` イベント emit
  - 処理中は disabled でスピナー効果
- **`BookmarkList.vue`・`App.vue`**: `bookmark-deleted` イベントをバブリングして `removeItemAccount` を呼び出す

### 外部レビュー対応（アクセシビリティ・UX 改善）

受け入れた指摘事項:

- **`:focus-visible` グローバル CSS**: キーボード操作時のフォーカスリングを明示（マウス操作では非表示）
- **sidebar-toggle の `aria-label` / `aria-expanded`**: スクリーンリーダー対応
- **コントラスト改善**: `--color-text-secondary` を `#71767b` → `#8b9098` に変更
- **`--color-success` / `--color-error` CSS 変数**: ハードコードされたカラーコードを変数化し、`CrawlStatus.vue`・`BookmarkCard.vue` で参照
- **`@media (prefers-reduced-motion: reduce)`**: アニメーション軽減設定に対応
- **見出し階層の修正**: `AccountFilter.vue`・`CategoryFilter.vue` の見出しを `h3` → `h2` に変更
- **`.text-link` のアンダーライン**: ホバー時のみ → 常時表示に変更
- **`article` 要素の `role` / `aria-label`**: `BookmarkCard` に `role="article"` と `:aria-label` を追加
- **`time` 要素の `:datetime`**: 機械可読な日時属性を追加
- **検索デバウンス**: 200ms のデバウンスを導入し、入力ごとに API リクエストが飛ぶ問題を解消
- **`meta description`**: `index.html` にページ説明メタタグを追加

今回対応しなかった指摘事項（スコープ外または後続対応）:

| 項目 | 内容 | 見送り理由 |
|------|------|-----------|
| H-1 | タッチターゲット 44px 化 | 既存ボタン・リスト要素の全面 CSS 改修が必要。別途対応 |
| H-3 | 検索入力への `<label>` 追加 | レイアウト変更を伴うため別途対応 |
| H-5 | ライトモード対応 | 大規模な配色設計変更が必要。別途 Issue で対応 |
| M-4 | `AccountFilter` の `<li role="button">` → `<button>` 化 | スタイルのリセット対応を伴うため別途対応 |
| M-7 | `alert`/`confirm` → モーダルダイアログ化 | UI コンポーネント新規実装が必要。別途対応 |
| M-8 | 単位を `px` → `rem` に統一 | 全コンポーネントの一括変更が必要。別途対応 |
| L-3 | 仮想スクロール導入 | パフォーマンス最適化として別途 Issue で対応 |
| L-4 | ソートボタン UI 変更 | 機能追加のため別途対応 |
| L-6 | カード表示アニメーション | 別途対応 |

## 関連 Issue

Closes #18
Closes #19
Closes #20