### PR TITLE
chore(pnpm): @book000/* パッケージを minimumReleaseAge チェックから除外

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ packages:
 allowBuilds:
   better-sqlite3: true
   esbuild: true
+minimumReleaseAgeExclude:
+  - '@book000/*'


### PR DESCRIPTION
## 概要

pnpm v11 のデフォルト `minimumReleaseAge`（24 時間）により、`@book000/*` パッケージが公開直後に Renovate PR の Docker CI が失敗するケースがあった（例: #84）。

## 変更内容

`pnpm-workspace.yaml` に `minimumReleaseAgeExclude` を追加し、`@book000/*` スコープのパッケージを pnpm の最小リリース日齢チェックから除外する。

```yaml
minimumReleaseAgeExclude:
  - '@book000/*'
```

## 背景・理由

既存の Renovate 設定（`book000/templates//renovate/base-public` 経由）では、`@book000/*` パッケージは `stabilityDays` チェックから除外されており、公開直後でも PR が作成される設定になっている。

pnpm 側の `minimumReleaseAge` チェックはこの意図と整合していなかったため、今回の変更で揃える。

## テスト計画

- [ ] CI（Node CI / Docker CI）がパスすること
- [ ] `@book000/*` パッケージを含む Renovate PR で Docker CI が `minimumReleaseAge` エラーを出さないこと