### PR TITLE
fix: @hono/node-server v2 の型解決に必要な @types/ws を追加

### DIFF
--- a/crawler/.depcheckrc.json
+++ b/crawler/.depcheckrc.json
@@ -3,6 +3,7 @@
     "@types/node",
     "@types/node-cron",
     "@types/tough-cookie",
+    "@types/ws",
     "run-z",
     "eslint-config-standard",
     "eslint-plugin-import",

--- a/crawler/package.json
+++ b/crawler/package.json
@@ -31,6 +31,7 @@
     "@types/node": "24.12.4",
     "@types/node-cron": "3.0.11",
     "@types/tough-cookie": "4.0.5",
+    "@types/ws": "^8.18.1",
     "eslint": "10.4.0",
     "prettier": "3.8.3",
     "run-z": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@types/tough-cookie':
         specifier: 4.0.5
         version: 4.0.5
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       eslint:
         specifier: 10.4.0
         version: 10.4.0
@@ -160,6 +163,9 @@ importers:
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       eslint:
         specifier: 10.4.0
         version: 10.4.0
@@ -1369,6 +1375,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.59.4':
     resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
@@ -4604,6 +4613,10 @@ snapshots:
   '@types/triple-beam@1.3.5': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.0
 
   '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:

--- a/viewer/backend/.depcheckrc.json
+++ b/viewer/backend/.depcheckrc.json
@@ -1,6 +1,7 @@
 {
   "ignores": [
     "@types/node",
+    "@types/ws",
     "run-z",
     "eslint-config-standard",
     "eslint-plugin-import",

--- a/viewer/backend/package.json
+++ b/viewer/backend/package.json
@@ -25,6 +25,7 @@
     "@book000/eslint-config": "1.14.40",
     "@types/better-sqlite3": "7.6.13",
     "@types/node": "24.12.4",
+    "@types/ws": "^8.18.1",
     "eslint": "10.4.0",
     "prettier": "3.8.3",
     "run-z": "2.1.0",


### PR DESCRIPTION
## 概要

`@hono/node-server@2.0.3` の型定義ファイル (`dist/index.d.mts`) が `ws` モジュールを参照するようになったため、`@types/ws` が存在しないと TypeScript のコンパイルエラーが発生します。

**エラー内容:**
```
error TS7016: Could not find a declaration file for module 'ws'.
'.../@hono/node-server@2.0.3/node_modules/@hono/node-server/dist/index.d.mts':5:44
```

## 変更内容

`@hono/node-server` を依存関係に持つ以下の 2 パッケージに対して修正を行いました。

### 1. `@types/ws` の追加 (`devDependencies`)

- `crawler/package.json`
- `viewer/backend/package.json`

### 2. `depcheck` の ignore リストに `@types/ws` を追加

`@types/ws` はコード内で `ws` を直接 `import` しないため、`depcheck` に未使用と判定されて CI が失敗します。他の `@types/*` パッケージ (`@types/node` など) と同様に、`depcheck` の ignore リストに追加しました。

- `crawler/.depcheckrc.json`
- `viewer/backend/.depcheckrc.json`

## 関連

Renovate PR #41 (`fix(deps): update dependency @hono/node-server to v2`) の Node CI 失敗の原因となっている型エラーを修正するための変更です。