### PR TITLE
feat(viewer): Grok 翻訳テキストをデフォルト表示し原文への切り替えを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@
         "password": "your_password",
         "otp_secret": null
       }
-    ]
+    ],
+    "clientLanguage": "ja"
   }
 }
 ```
 
 > `otp_secret` は 2 段階認証 (TOTP) を使用している場合に設定します。
+
+> `clientLanguage` は Twitter API クライアントの言語コード (BCP47) です。`x-twitter-client-language` ヘッダーとして送信され、Grok 翻訳先言語など API レスポンスの言語に影響します。省略時は `ja` (日本語) になります。
 
 ### 2. 環境変数の設定 (任意)
 

--- a/crawler/src/core/crawler.ts
+++ b/crawler/src/core/crawler.ts
@@ -164,7 +164,11 @@ export async function runCrawl(db: Database.Database): Promise<void> {
       logger.info(`===== Account: ${account.username} =====`)
       try {
         const { authToken, ct0 } = await getAuthCookies(account)
-        const client = await getBookmarksClient(authToken, ct0)
+        const client = await getBookmarksClient(
+          authToken,
+          ct0,
+          config.twitter.clientLanguage
+        )
 
         let cursor: string | undefined
         let page = 0

--- a/crawler/src/infra/bookmarks-api.ts
+++ b/crawler/src/infra/bookmarks-api.ts
@@ -82,6 +82,43 @@ function extractMediaItems(legacy: {
 }
 
 /**
+ * Tweet オブジェクトから Grok 翻訳情報を抽出する。
+ * grokTranslatedPostWithAvailability が存在しない・利用不可・翻訳が空の場合は
+ * 全フィールド null・空配列を返す。
+ *
+ * @param tweet Twitter API の Tweet オブジェクト
+ * @returns 翻訳テキスト・言語コード・URL エンティティを含むオブジェクト
+ */
+function extractGrokTranslation(tweet: TweetApiUtilsData['tweet']): {
+  translatedText: string | null
+  sourceLanguage: string | null
+  destinationLanguage: string | null
+  translatedUrlEntities: BookmarkEntry['urlEntities']
+} {
+  const empty = {
+    translatedText: null,
+    sourceLanguage: null,
+    destinationLanguage: null,
+    translatedUrlEntities: [] as BookmarkEntry['urlEntities'],
+  }
+
+  const grok = tweet.grokTranslatedPostWithAvailability
+  // grok 翻訳が存在しない・利用不可の場合はスキップ
+  if (!grok?.isAvailable || !grok.data) return empty
+
+  const data = grok.data
+  // 翻訳テキストが空の場合はスキップ
+  if (!data.translation) return empty
+
+  return {
+    translatedText: data.translation,
+    sourceLanguage: data.sourceLanguage ?? null,
+    destinationLanguage: data.destinationLanguage ?? null,
+    translatedUrlEntities: extractUrlEntities(data.entities ?? {}),
+  }
+}
+
+/**
  * TweetApiUtilsData からブックマーク 1 件分のデータを抽出する。
  *
  * @param tweetResult TweetApiUtilsData
@@ -135,6 +172,7 @@ export function extractBookmarkEntry(
     const qtUserLegacy = qtUser.legacy
 
     if (qtLegacy && qtUserLegacy.screenName && qtUserLegacy.name) {
+      const qtGrok = extractGrokTranslation(qt.tweet)
       quotedTweet = {
         tweetId: qtLegacy.idStr,
         userId: qtUser.restId,
@@ -145,9 +183,16 @@ export function extractBookmarkEntry(
         profileImageUrl: qtUserLegacy.profileImageUrlHttps ?? null,
         mediaItems: extractMediaItems(qtLegacy),
         urlEntities: extractUrlEntities(qtLegacy.entities ?? {}),
+        translatedText: qtGrok.translatedText,
+        sourceLanguage: qtGrok.sourceLanguage,
+        destinationLanguage: qtGrok.destinationLanguage,
+        translatedUrlEntities: qtGrok.translatedUrlEntities,
       }
     }
   }
+
+  // Grok 翻訳情報の抽出
+  const grok = extractGrokTranslation(tweet)
 
   // カード情報の抽出（player / summary / summary_large_image）
   let cardPlayerUrl: string | null = null
@@ -207,6 +252,10 @@ export function extractBookmarkEntry(
     quotedTweet,
     cardPlayerUrl,
     cardInfo,
+    translatedText: grok.translatedText,
+    sourceLanguage: grok.sourceLanguage,
+    destinationLanguage: grok.destinationLanguage,
+    translatedUrlEntities: grok.translatedUrlEntities,
   }
 }
 

--- a/crawler/src/infra/bookmarks-api.ts
+++ b/crawler/src/infra/bookmarks-api.ts
@@ -388,5 +388,8 @@ export async function getBookmarksClient(
 ): Promise<TwitterOpenApiClient> {
   const api = new TwitterOpenApi()
   TwitterOpenApi.fetchApi = cycleTLSFetch
+  // twitter-openapi-typescript は x-twitter-client-language を 'en' でハードコードしているため
+  // 日本語翻訳 (Grok) を取得するために上書きする
+  api.setAdditionalApiHeaders({ 'x-twitter-client-language': 'ja' })
   return api.getClientFromCookies({ auth_token: authToken, ct0 })
 }

--- a/crawler/src/infra/bookmarks-api.ts
+++ b/crawler/src/infra/bookmarks-api.ts
@@ -380,16 +380,18 @@ export async function removeBookmark(
  *
  * @param authToken auth_token Cookie の値
  * @param ct0 ct0 Cookie の値
+ * @param clientLanguage Twitter API クライアントの言語コード (BCP47)。API レスポンスの言語に影響する。省略時は 'ja'
  * @returns TwitterOpenApi クライアント
  */
 export async function getBookmarksClient(
   authToken: string,
-  ct0: string
+  ct0: string,
+  clientLanguage = 'ja'
 ): Promise<TwitterOpenApiClient> {
   const api = new TwitterOpenApi()
   TwitterOpenApi.fetchApi = cycleTLSFetch
-  // twitter-openapi-typescript は x-twitter-client-language を 'en' でハードコードしているため
-  // 日本語翻訳 (Grok) を取得するために上書きする
-  api.setAdditionalApiHeaders({ 'x-twitter-client-language': 'ja' })
+  // twitter-openapi-typescript は x-twitter-client-language を 'en' でハードコードしているため上書きする。
+  // このヘッダーは Grok 翻訳先言語を含む API レスポンスの言語全体に影響する
+  api.setAdditionalApiHeaders({ 'x-twitter-client-language': clientLanguage })
   return api.getClientFromCookies({ auth_token: authToken, ct0 })
 }

--- a/crawler/src/infra/bookmarks-api.ts
+++ b/crawler/src/infra/bookmarks-api.ts
@@ -137,9 +137,9 @@ export function extractBookmarkEntry(
   // User.restId は必須フィールドのため fallback 不要
   const userId = user.restId
   const fullText = legacy?.fullText
-  // UserLegacy.screenName / name は必須フィールドのため optional chain 不要
-  const screenName = userLegacy.screenName
-  const userName = userLegacy.name
+  // Twitter API 変更により screenName/name は user.core に移動した（user.legacy をフォールバックとして保持）
+  const screenName = user.core?.screenName ?? userLegacy.screenName
+  const userName = user.core?.name ?? userLegacy.name
   // Twitter API は "Wed Sep 24 11:28:06 +0000 2025" 形式で返すため ISO 8601 に変換する
   const createdAt = legacy?.createdAt
     ? new Date(legacy.createdAt).toISOString()
@@ -171,16 +171,20 @@ export function extractBookmarkEntry(
     // User.legacy は必須フィールドのため optional chain 不要
     const qtUserLegacy = qtUser.legacy
 
-    if (qtLegacy && qtUserLegacy.screenName && qtUserLegacy.name) {
+    // Twitter API 変更により screenName/name は qtUser.core に移動した（qtUserLegacy をフォールバックとして保持）
+    const qtScreenName = qtUser.core?.screenName ?? qtUserLegacy.screenName
+    const qtUserName = qtUser.core?.name ?? qtUserLegacy.name
+    if (qtLegacy && qtScreenName && qtUserName) {
       const qtGrok = extractGrokTranslation(qt.tweet)
       quotedTweet = {
         tweetId: qtLegacy.idStr,
         userId: qtUser.restId,
         fullText: qtLegacy.fullText,
         createdAt: new Date(qtLegacy.createdAt).toISOString(),
-        screenName: qtUserLegacy.screenName,
-        userName: qtUserLegacy.name,
-        profileImageUrl: qtUserLegacy.profileImageUrlHttps ?? null,
+        screenName: qtScreenName,
+        userName: qtUserName,
+        profileImageUrl:
+          qtUser.avatar?.imageUrl ?? qtUserLegacy.profileImageUrlHttps ?? null,
         mediaItems: extractMediaItems(qtLegacy),
         urlEntities: extractUrlEntities(qtLegacy.entities ?? {}),
         translatedText: qtGrok.translatedText,
@@ -245,7 +249,8 @@ export function extractBookmarkEntry(
     fullText,
     screenName,
     userName,
-    profileImageUrl: userLegacy.profileImageUrlHttps ?? null,
+    profileImageUrl:
+      user.avatar?.imageUrl ?? userLegacy.profileImageUrlHttps ?? null,
     createdAt,
     mediaItems,
     urlEntities,

--- a/crawler/src/infra/database.ts
+++ b/crawler/src/infra/database.ts
@@ -115,9 +115,9 @@ function upsertTweetRecord(
       card_title           = excluded.card_title,
       card_description     = excluded.card_description,
       card_thumbnail_url   = excluded.card_thumbnail_url,
-      translated_text      = excluded.translated_text,
-      source_language      = excluded.source_language,
-      destination_language = excluded.destination_language
+      translated_text      = COALESCE(excluded.translated_text, tweets.translated_text),
+      source_language      = COALESCE(excluded.source_language, tweets.source_language),
+      destination_language = COALESCE(excluded.destination_language, tweets.destination_language)
   `
   ).run(
     record.tweetId,
@@ -169,22 +169,24 @@ function upsertTweetRecord(
     )
   }
 
-  // 翻訳用 url_entities を差し替える
-  db.prepare('DELETE FROM url_entities WHERE tweet_id = ? AND kind = ?').run(
-    record.tweetId,
-    'translated'
-  )
-  const insertTranslatedUrl = db.prepare(
-    'INSERT INTO url_entities (tweet_id, url, expanded_url, display_url, kind) VALUES (?, ?, ?, ?, ?)'
-  )
-  for (const entity of record.translatedUrlEntities) {
-    insertTranslatedUrl.run(
+  // 翻訳テキストがある場合のみ翻訳用 url_entities を差し替える（null 時は既存データを保持）
+  if (record.translatedText !== null) {
+    db.prepare('DELETE FROM url_entities WHERE tweet_id = ? AND kind = ?').run(
       record.tweetId,
-      entity.url,
-      entity.expandedUrl,
-      entity.displayUrl,
       'translated'
     )
+    const insertTranslatedUrl = db.prepare(
+      'INSERT INTO url_entities (tweet_id, url, expanded_url, display_url, kind) VALUES (?, ?, ?, ?, ?)'
+    )
+    for (const entity of record.translatedUrlEntities) {
+      insertTranslatedUrl.run(
+        record.tweetId,
+        entity.url,
+        entity.expandedUrl,
+        entity.displayUrl,
+        'translated'
+      )
+    }
   }
 }
 

--- a/crawler/src/infra/database.ts
+++ b/crawler/src/infra/database.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3'
-import { SCHEMA_DDL } from '@twitter-bookmark-hub/shared'
+import { SCHEMA_DDL, applyColumnMigrations } from '@twitter-bookmark-hub/shared'
 import type { BookmarkEntry } from '../shared/types'
 
 /**
@@ -17,6 +17,7 @@ export function initDatabase(dbPath: string): Database.Database {
   db.pragma('foreign_keys=ON')
 
   db.exec(SCHEMA_DDL)
+  applyColumnMigrations(db)
 
   return db
 }
@@ -63,6 +64,14 @@ interface TweetRecord {
   urlEntities: BookmarkEntry['urlEntities']
   cardPlayerUrl: string | null
   cardInfo: BookmarkEntry['cardInfo']
+  /** Grok 翻訳テキスト（翻訳がない場合は null） */
+  translatedText: string | null
+  /** 翻訳元言語コード (BCP47。翻訳がない場合は null) */
+  sourceLanguage: string | null
+  /** 翻訳先言語コード (BCP47。翻訳がない場合は null) */
+  destinationLanguage: string | null
+  /** 翻訳テキスト内の URL エンティティ（翻訳がない場合は空配列） */
+  translatedUrlEntities: BookmarkEntry['urlEntities']
 }
 
 /**
@@ -92,19 +101,23 @@ function upsertTweetRecord(
     `
     INSERT INTO tweets (
       tweet_id, user_id, full_text, created_at, quoted_tweet_id,
-      card_type, card_url, card_vanity_url, card_title, card_description, card_thumbnail_url
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      card_type, card_url, card_vanity_url, card_title, card_description, card_thumbnail_url,
+      translated_text, source_language, destination_language
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(tweet_id) DO UPDATE SET
-      user_id            = excluded.user_id,
-      full_text          = excluded.full_text,
-      created_at         = excluded.created_at,
-      quoted_tweet_id    = excluded.quoted_tweet_id,
-      card_type          = excluded.card_type,
-      card_url           = excluded.card_url,
-      card_vanity_url    = excluded.card_vanity_url,
-      card_title         = excluded.card_title,
-      card_description   = excluded.card_description,
-      card_thumbnail_url = excluded.card_thumbnail_url
+      user_id              = excluded.user_id,
+      full_text            = excluded.full_text,
+      created_at           = excluded.created_at,
+      quoted_tweet_id      = excluded.quoted_tweet_id,
+      card_type            = excluded.card_type,
+      card_url             = excluded.card_url,
+      card_vanity_url      = excluded.card_vanity_url,
+      card_title           = excluded.card_title,
+      card_description     = excluded.card_description,
+      card_thumbnail_url   = excluded.card_thumbnail_url,
+      translated_text      = excluded.translated_text,
+      source_language      = excluded.source_language,
+      destination_language = excluded.destination_language
   `
   ).run(
     record.tweetId,
@@ -117,7 +130,10 @@ function upsertTweetRecord(
     record.cardInfo?.vanityUrl ?? null,
     record.cardInfo?.title ?? null,
     record.cardInfo?.description ?? null,
-    record.cardInfo?.thumbnailUrl ?? null
+    record.cardInfo?.thumbnailUrl ?? null,
+    record.translatedText,
+    record.sourceLanguage,
+    record.destinationLanguage
   )
 
   // media_items を差し替える
@@ -135,13 +151,40 @@ function upsertTweetRecord(
     )
   }
 
-  // url_entities を差し替える
-  db.prepare('DELETE FROM url_entities WHERE tweet_id = ?').run(record.tweetId)
+  // オリジナル url_entities を差し替える（翻訳用エンティティは削除しない）
+  db.prepare('DELETE FROM url_entities WHERE tweet_id = ? AND kind = ?').run(
+    record.tweetId,
+    'original'
+  )
   const insertUrl = db.prepare(
-    'INSERT INTO url_entities (tweet_id, url, expanded_url, display_url) VALUES (?, ?, ?, ?)'
+    'INSERT INTO url_entities (tweet_id, url, expanded_url, display_url, kind) VALUES (?, ?, ?, ?, ?)'
   )
   for (const ue of record.urlEntities) {
-    insertUrl.run(record.tweetId, ue.url, ue.expandedUrl, ue.displayUrl)
+    insertUrl.run(
+      record.tweetId,
+      ue.url,
+      ue.expandedUrl,
+      ue.displayUrl,
+      'original'
+    )
+  }
+
+  // 翻訳用 url_entities を差し替える
+  db.prepare('DELETE FROM url_entities WHERE tweet_id = ? AND kind = ?').run(
+    record.tweetId,
+    'translated'
+  )
+  const insertTranslatedUrl = db.prepare(
+    'INSERT INTO url_entities (tweet_id, url, expanded_url, display_url, kind) VALUES (?, ?, ?, ?, ?)'
+  )
+  for (const entity of record.translatedUrlEntities) {
+    insertTranslatedUrl.run(
+      record.tweetId,
+      entity.url,
+      entity.expandedUrl,
+      entity.displayUrl,
+      'translated'
+    )
   }
 }
 
@@ -192,6 +235,10 @@ export const upsertTweetEntry = (
           urlEntities: qt.urlEntities,
           cardPlayerUrl: null,
           cardInfo: null,
+          translatedText: qt.translatedText,
+          sourceLanguage: qt.sourceLanguage,
+          destinationLanguage: qt.destinationLanguage,
+          translatedUrlEntities: qt.translatedUrlEntities,
         },
         null
       )

--- a/crawler/src/infra/database.ts
+++ b/crawler/src/infra/database.ts
@@ -76,9 +76,11 @@ interface TweetRecord {
 
 /**
  * ツイートレコードを upsert する（users への依存を前提とする）。
- * media_items・url_entities は削除してから再挿入する。
+ * media_items と kind='original' の url_entities は削除してから再挿入する。
+ * kind='translated' の url_entities は translatedText が非 null の場合のみ削除・再挿入し、
+ * null の場合は既存データを保持する（再クロール時に Grok が翻訳を返さなかった場合の消失を防ぐため）。
  * この関数は呼び出し元のトランザクション内で実行されることを前提とする。
- * 単独で呼び出した場合、media_items の削除と再挿入が原子的に行われない。
+ * 単独で呼び出した場合、削除と再挿入が原子的に行われない。
  *
  * @param db Database インスタンス
  * @param record ツイートレコード

--- a/crawler/src/shared/types.ts
+++ b/crawler/src/shared/types.ts
@@ -69,4 +69,12 @@ export interface BookmarkEntry {
   cardPlayerUrl: string | null
   /** リンクカード情報（OGP 相当） */
   cardInfo: CardInfo | null
+  /** Grok 翻訳テキスト（翻訳がない場合は null） */
+  translatedText: string | null
+  /** 翻訳元言語コード (BCP47、例: 'en'。翻訳がない場合は null) */
+  sourceLanguage: string | null
+  /** 翻訳先言語コード (BCP47、例: 'ja'。翻訳がない場合は null) */
+  destinationLanguage: string | null
+  /** 翻訳テキスト内の URL エンティティ（t.co を展開 URL に置換するために使用。翻訳がない場合は空配列） */
+  translatedUrlEntities: BookmarkEntry['urlEntities']
 }

--- a/crawler/src/shared/types.ts
+++ b/crawler/src/shared/types.ts
@@ -30,6 +30,13 @@ export interface AppConfig {
   twitter: {
     /** アカウント一覧 */
     accounts: AccountConfig[]
+    /**
+     * Twitter API クライアントの言語コード (BCP47)。
+     * x-twitter-client-language ヘッダーとして送信され、
+     * API レスポンスの言語（Grok 翻訳先言語を含む）に影響する。
+     * 省略時は 'ja'。
+     */
+    clientLanguage?: string
   }
 }
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,4 @@
-export { SCHEMA_DDL } from './schema'
+export { SCHEMA_DDL, COLUMN_MIGRATIONS, applyColumnMigrations } from "./schema";
 export type {
   CardInfo,
   MediaItem,
@@ -12,4 +12,4 @@ export type {
   CategoryItem,
   AnalyzeResponse,
   FeaturesResponse,
-} from './types'
+} from "./types";

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -24,6 +24,9 @@ export const SCHEMA_DDL = `
     card_title         TEXT,
     card_description   TEXT,
     card_thumbnail_url TEXT,
+    translated_text       TEXT,
+    source_language       TEXT,
+    destination_language  TEXT,
     FOREIGN KEY (user_id) REFERENCES users(user_id),
     FOREIGN KEY (quoted_tweet_id) REFERENCES tweets(tweet_id)
   );
@@ -44,6 +47,7 @@ export const SCHEMA_DDL = `
     url          TEXT NOT NULL,
     expanded_url TEXT NOT NULL,
     display_url  TEXT NOT NULL,
+    kind         TEXT NOT NULL DEFAULT 'original',
     FOREIGN KEY (tweet_id) REFERENCES tweets(tweet_id)
   );
 
@@ -102,4 +106,43 @@ export const SCHEMA_DDL = `
 
   CREATE INDEX IF NOT EXISTS idx_tweet_tags_tag_id           ON tweet_tags(tag_id);
   CREATE INDEX IF NOT EXISTS idx_tweet_categories_cat_id     ON tweet_categories(category_id);
-`
+`;
+
+/** 既存 DB 向けのカラム追加マイグレーション定義 */
+export const COLUMN_MIGRATIONS = [
+  {
+    table: "tweets",
+    column: "translated_text",
+    ddl: "ALTER TABLE tweets ADD COLUMN translated_text TEXT",
+  },
+  {
+    table: "tweets",
+    column: "source_language",
+    ddl: "ALTER TABLE tweets ADD COLUMN source_language TEXT",
+  },
+  {
+    table: "tweets",
+    column: "destination_language",
+    ddl: "ALTER TABLE tweets ADD COLUMN destination_language TEXT",
+  },
+  {
+    table: "url_entities",
+    column: "kind",
+    ddl: "ALTER TABLE url_entities ADD COLUMN kind TEXT NOT NULL DEFAULT 'original'",
+  },
+] as const;
+
+/** PRAGMA table_info でカラムの存在を確認し、未存在の場合のみ ALTER TABLE を実行する */
+export function applyColumnMigrations(db: {
+  prepare: (sql: string) => { all: () => unknown[] };
+  exec: (sql: string) => void;
+}): void {
+  for (const migration of COLUMN_MIGRATIONS) {
+    const columns = db
+      .prepare(`PRAGMA table_info(${migration.table})`)
+      .all() as { name: string }[];
+    if (!columns.some((c) => c.name === migration.column)) {
+      db.exec(migration.ddl);
+    }
+  }
+}

--- a/shared/src/schema.ts
+++ b/shared/src/schema.ts
@@ -132,7 +132,12 @@ export const COLUMN_MIGRATIONS = [
   },
 ] as const;
 
-/** PRAGMA table_info でカラムの存在を確認し、未存在の場合のみ ALTER TABLE を実行する */
+/**
+ * 既存 DB に対してカラム追加マイグレーションを適用する。
+ * PRAGMA table_info でカラムの存在を確認し、未存在の場合のみ ALTER TABLE を実行する。
+ *
+ * @param db PRAGMA クエリと DDL 実行が可能な DB インスタンス（better-sqlite3 互換）
+ */
 export function applyColumnMigrations(db: {
   prepare: (sql: string) => { all: () => unknown[] };
   exec: (sql: string) => void;

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,37 +1,37 @@
 /** リンクカード情報（OGP 相当） */
 export interface CardInfo {
   /** カード種別 */
-  cardType: 'summary' | 'summary_large_image'
+  cardType: "summary" | "summary_large_image";
   /** リンク先 URL */
-  cardUrl: string
+  cardUrl: string;
   /** 表示用ドメイン */
-  vanityUrl: string
+  vanityUrl: string;
   /** 記事タイトル */
-  title: string
+  title: string;
   /** 記事概要 */
-  description: string
+  description: string;
   /** サムネイル画像 URL */
-  thumbnailUrl: string | null
+  thumbnailUrl: string | null;
 }
 
 /** メディアアイテム（写真・動画・GIF） */
 export interface MediaItem {
   /** メディア種別 */
-  type: 'photo' | 'video' | 'animated_gif'
+  type: "photo" | "video" | "animated_gif";
   /** サムネイル画像 URL */
-  thumbUrl: string
+  thumbUrl: string;
   /** 動画 URL（video / animated_gif の場合のみ） */
-  videoUrl?: string
+  videoUrl?: string;
 }
 
 /** URL エンティティ（t.co → 展開 URL のマッピング） */
 export interface UrlEntity {
   /** t.co 短縮 URL */
-  url: string
+  url: string;
   /** 展開後の URL */
-  expandedUrl: string
+  expandedUrl: string;
   /** 表示用 URL（ドメイン + パス短縮） */
-  displayUrl: string
+  displayUrl: string;
 }
 
 /**
@@ -40,147 +40,163 @@ export interface UrlEntity {
  */
 export interface QuotedTweet {
   /** ツイート ID */
-  tweetId: string
+  tweetId: string;
   /** ユーザー ID (Twitter Snowflake ID) */
-  userId: string
+  userId: string;
   /** ツイート本文 */
-  fullText: string
+  fullText: string;
   /** 投稿日時 (UTC ISO 8601 文字列) */
-  createdAt: string
+  createdAt: string;
   /** スクリーンネーム */
-  screenName: string
+  screenName: string;
   /** 表示名 */
-  userName: string
+  userName: string;
   /** プロフィール画像 URL */
-  profileImageUrl: string | null
+  profileImageUrl: string | null;
   /** メディアアイテム一覧 */
-  mediaItems: MediaItem[]
+  mediaItems: MediaItem[];
   /** URL エンティティ */
-  urlEntities: UrlEntity[]
+  urlEntities: UrlEntity[];
+  /** Grok 翻訳テキスト（翻訳がない場合は null） */
+  translatedText: string | null;
+  /** 翻訳元言語コード (BCP47、例: 'en'。翻訳がない場合は null) */
+  sourceLanguage: string | null;
+  /** 翻訳先言語コード (BCP47、例: 'ja'。翻訳がない場合は null) */
+  destinationLanguage: string | null;
+  /** 翻訳テキスト内の URL エンティティ（t.co を展開 URL に置換するために使用。翻訳がない場合は空配列） */
+  translatedUrlEntities: UrlEntity[];
 }
 
 /** ブックマーク一覧 API のレスポンスアイテム */
 export interface BookmarkItem {
   /** ツイート ID */
-  tweetId: string
+  tweetId: string;
   /** ツイート本文 */
-  fullText: string
+  fullText: string;
   /** スクリーンネーム (@名) */
-  screenName: string
+  screenName: string;
   /** ユーザー表示名 */
-  userName: string
+  userName: string;
   /** プロフィール画像 URL */
-  profileImageUrl: string | null
+  profileImageUrl: string | null;
   /** ツイート作成日時 */
-  createdAt: string
+  createdAt: string;
   /** 初回ブックマーク発見日時 */
-  bookmarkedAt: string
+  bookmarkedAt: string;
   /** ツイート URL（screen_name + tweet_id から導出） */
-  tweetUrl: string
+  tweetUrl: string;
   /** メディアアイテム一覧（写真・動画・GIF） */
-  mediaItems: MediaItem[]
+  mediaItems: MediaItem[];
   /** このツイートをブックマークしているアカウント一覧 */
-  bookmarkedBy: string[]
+  bookmarkedBy: string[];
   /** URL エンティティ（t.co → 展開 URL） */
-  urlEntities: UrlEntity[]
+  urlEntities: UrlEntity[];
+  /** Grok 翻訳テキスト（翻訳がない場合は null） */
+  translatedText: string | null;
+  /** 翻訳元言語コード (BCP47、例: 'en'。翻訳がない場合は null) */
+  sourceLanguage: string | null;
+  /** 翻訳先言語コード (BCP47、例: 'ja'。翻訳がない場合は null) */
+  destinationLanguage: string | null;
+  /** 翻訳テキスト内の URL エンティティ（t.co を展開 URL に置換するために使用。翻訳がない場合は空配列） */
+  translatedUrlEntities: UrlEntity[];
   /** 引用ツイート情報 */
-  quotedTweet: QuotedTweet | null
+  quotedTweet: QuotedTweet | null;
   /** カード動画プレーヤー URL（YouTube 等の embed URL） */
-  cardPlayerUrl: string | null
+  cardPlayerUrl: string | null;
   /** リンクカード情報（OGP 相当） */
-  cardInfo: CardInfo | null
+  cardInfo: CardInfo | null;
   /** analyzer が付与したタグ一覧（analyzer が無効の場合は空配列） */
-  tags: string[]
+  tags: string[];
   /** analyzer が付与したカテゴリ一覧（analyzer が無効の場合は空配列） */
   categories: Array<{
     /** カテゴリ ID */
-    id: number
+    id: number;
     /** カテゴリ名 */
-    name: string
+    name: string;
     /** UI 表示用カラーコード */
-    color: string
-  }>
+    color: string;
+  }>;
 }
 
 /** ブックマーク一覧 API のレスポンス */
 export interface BookmarksResponse {
   /** ブックマークアイテム一覧 */
-  items: BookmarkItem[]
+  items: BookmarkItem[];
   /** 総件数 */
-  total: number
+  total: number;
   /** 現在のページ番号 */
-  page: number
+  page: number;
   /** 1 ページあたりの件数 */
-  limit: number
+  limit: number;
 }
 
 /** アカウント情報 */
 export interface AccountInfo {
   /** アカウントのユーザー名 */
-  username: string
+  username: string;
   /** ブックマーク件数 */
-  bookmarkCount: number
+  bookmarkCount: number;
 }
 
 /** タグアイテム（形態素解析で抽出された名詞） */
 export interface TagItem {
   /** タグ ID */
-  id: number
+  id: number;
   /** タグ名（抽出された名詞） */
-  name: string
+  name: string;
   /** このタグが付いたツイート数 */
-  count: number
+  count: number;
 }
 
 /** カテゴリアイテム（ユーザー定義のカテゴリ） */
 export interface CategoryItem {
   /** カテゴリ ID */
-  id: number
+  id: number;
   /** カテゴリ名 */
-  name: string
+  name: string;
   /** UI 表示用カラーコード */
-  color: string
+  color: string;
   /** マッチングキーワード一覧 */
-  keywords: string[]
+  keywords: string[];
   /** 作成日時 (ISO 8601) */
-  createdAt: string
+  createdAt: string;
   /** このカテゴリに属するブックマーク件数 */
-  bookmarkCount?: number
+  bookmarkCount?: number;
 }
 
 /** analyzer の POST /analyze レスポンス */
 export interface AnalyzeResponse {
   /** 抽出されたタグ（名詞）一覧 */
-  tags: string[]
+  tags: string[];
   /** マッチしたカテゴリと信頼度スコア */
   categories: Array<{
     /** カテゴリ ID */
-    id: number
+    id: number;
     /** 信頼度スコア（0.0〜1.0） */
-    confidence: number
-  }>
+    confidence: number;
+  }>;
 }
 
 /** 機能フラグ（analyzer の有効/無効など） */
 export interface FeaturesResponse {
   /** analyzer サービスが有効かどうか */
-  analyzer: boolean
+  analyzer: boolean;
 }
 
 /** クロールジョブのステータス */
 export interface CrawlJobStatus {
   /** ジョブ ID */
-  id: number
+  id: number;
   /** 開始日時 (ISO 8601) */
-  startedAt: string
+  startedAt: string;
   /** 終了日時 (ISO 8601)。実行中は null */
-  finishedAt: string | null
+  finishedAt: string | null;
   /** ジョブステータス */
-  status: 'running' | 'success' | 'error'
+  status: "running" | "success" | "error";
   /** エラーメッセージ（エラー時のみ） */
-  errorMessage: string | null
+  errorMessage: string | null;
   /** 対象アカウント総数 */
-  accountsTotal: number | null
+  accountsTotal: number | null;
   /** 成功アカウント数 */
-  accountsSucceeded: number | null
+  accountsSucceeded: number | null;
 }

--- a/viewer/backend/src/infra/database.ts
+++ b/viewer/backend/src/infra/database.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3'
-import { SCHEMA_DDL } from '@twitter-bookmark-hub/shared'
+import { SCHEMA_DDL, applyColumnMigrations } from '@twitter-bookmark-hub/shared'
 import type {
   CardInfo,
   CrawlJobStatus,
@@ -53,6 +53,9 @@ export function openDatabase(dbPath: string): Database.Database {
 
   // crawler が先に起動していない場合に備えてテーブルを作成
   db.exec(SCHEMA_DDL)
+
+  // 既存 DB に対してカラム追加マイグレーションを適用する
+  applyColumnMigrations(db)
 
   return db
 }
@@ -269,6 +272,9 @@ export function getBookmarks(
       t.card_title,
       t.card_description,
       t.card_thumbnail_url,
+      t.translated_text,
+      t.source_language,
+      t.destination_language,
       u.screen_name,
       u.user_name,
       u.profile_image_url,
@@ -291,15 +297,27 @@ export function getBookmarks(
           'displayUrl', ue.display_url
         ))
         FROM url_entities ue
-        WHERE ue.tweet_id = t.tweet_id
+        WHERE ue.tweet_id = t.tweet_id AND (ue.kind = 'original' OR ue.kind IS NULL)
       ) AS url_entities,
-      qt.tweet_id        AS qt_tweet_id,
-      qt.full_text       AS qt_full_text,
-      qt.user_id         AS qt_user_id,
-      qt.created_at      AS qt_created_at,
-      qu.screen_name     AS qt_screen_name,
-      qu.user_name       AS qt_user_name,
-      qu.profile_image_url AS qt_profile_image_url,
+      (
+        SELECT json_group_array(json_object(
+          'url', ue.url,
+          'expandedUrl', ue.expanded_url,
+          'displayUrl', ue.display_url
+        ))
+        FROM url_entities ue
+        WHERE ue.tweet_id = t.tweet_id AND ue.kind = 'translated'
+      ) AS translated_url_entities,
+      qt.tweet_id              AS qt_tweet_id,
+      qt.full_text             AS qt_full_text,
+      qt.user_id               AS qt_user_id,
+      qt.created_at            AS qt_created_at,
+      qt.translated_text       AS qt_translated_text,
+      qt.source_language       AS qt_source_language,
+      qt.destination_language  AS qt_destination_language,
+      qu.screen_name           AS qt_screen_name,
+      qu.user_name             AS qt_user_name,
+      qu.profile_image_url     AS qt_profile_image_url,
       (
         SELECT json_group_array(json_object(
           'type', mi.type,
@@ -317,8 +335,17 @@ export function getBookmarks(
           'displayUrl', ue.display_url
         ))
         FROM url_entities ue
-        WHERE ue.tweet_id = t.quoted_tweet_id
-      ) AS qt_url_entities${
+        WHERE ue.tweet_id = t.quoted_tweet_id AND (ue.kind = 'original' OR ue.kind IS NULL)
+      ) AS qt_url_entities,
+      (
+        SELECT json_group_array(json_object(
+          'url', ue.url,
+          'expandedUrl', ue.expanded_url,
+          'displayUrl', ue.display_url
+        ))
+        FROM url_entities ue
+        WHERE ue.tweet_id = t.quoted_tweet_id AND ue.kind = 'translated'
+      ) AS qt_translated_url_entities${
         tagsTableExists
           ? `,
       (
@@ -368,15 +395,23 @@ export function getBookmarks(
     bookmarked_by: string
     media_items: string | null
     url_entities: string | null
+    translated_text: string | null
+    source_language: string | null
+    destination_language: string | null
+    translated_url_entities: string | null
     qt_tweet_id: string | null
     qt_full_text: string | null
     qt_user_id: string | null
     qt_created_at: string | null
+    qt_translated_text: string | null
+    qt_source_language: string | null
+    qt_destination_language: string | null
     qt_screen_name: string | null
     qt_user_name: string | null
     qt_profile_image_url: string | null
     qt_media_items: string | null
     qt_url_entities: string | null
+    qt_translated_url_entities: string | null
     tweet_tags_json?: string | null
     tweet_categories_json?: string | null
   }[]
@@ -395,6 +430,10 @@ export function getBookmarks(
         profileImageUrl: row.qt_profile_image_url,
         mediaItems: parseMediaItems(row.qt_media_items),
         urlEntities: parseUrlEntities(row.qt_url_entities),
+        translatedText: row.qt_translated_text,
+        sourceLanguage: row.qt_source_language,
+        destinationLanguage: row.qt_destination_language,
+        translatedUrlEntities: parseUrlEntities(row.qt_translated_url_entities),
       }
     }
 
@@ -430,6 +469,10 @@ export function getBookmarks(
       mediaItems: parseMediaItems(row.media_items),
       bookmarkedBy: row.bookmarked_by ? row.bookmarked_by.split(',') : [],
       urlEntities: parseUrlEntities(row.url_entities),
+      translatedText: row.translated_text,
+      sourceLanguage: row.source_language,
+      destinationLanguage: row.destination_language,
+      translatedUrlEntities: parseUrlEntities(row.translated_url_entities),
       quotedTweet,
       cardPlayerUrl,
       cardInfo,

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { BookmarkItem, UrlEntity } from '../api'
 import { deleteBookmark } from '../api'
 
@@ -231,6 +231,19 @@ const mainViewMode = ref<'translated' | 'original'>(
 /** 引用ツイートの表示モード（翻訳があればデフォルト 'translated'） */
 const quotedViewMode = ref<'translated' | 'original'>(
   properties.item.quotedTweet?.translatedText ? 'translated' : 'original'
+)
+
+// item が切り替わったときに表示モードをリセットする（コンポーネントインスタンス再利用時の残留を防ぐ）
+watch(
+  () => properties.item.tweetId,
+  () => {
+    mainViewMode.value = properties.item.translatedText
+      ? 'translated'
+      : 'original'
+    quotedViewMode.value = properties.item.quotedTweet?.translatedText
+      ? 'translated'
+      : 'original'
+  }
 )
 
 const textSegments = computed(() => {

--- a/viewer/frontend/src/components/BookmarkCard.vue
+++ b/viewer/frontend/src/components/BookmarkCard.vue
@@ -224,16 +224,65 @@ function parseTextSegments(
   return segments
 }
 
-const textSegments = computed(() =>
-  parseTextSegments(properties.item.fullText, properties.item.urlEntities)
+/** 主ツイートの表示モード（翻訳があればデフォルト 'translated'） */
+const mainViewMode = ref<'translated' | 'original'>(
+  properties.item.translatedText ? 'translated' : 'original'
 )
-const quotedTextSegments = computed(() => {
-  if (!properties.item.quotedTweet) return []
+/** 引用ツイートの表示モード（翻訳があればデフォルト 'translated'） */
+const quotedViewMode = ref<'translated' | 'original'>(
+  properties.item.quotedTweet?.translatedText ? 'translated' : 'original'
+)
+
+const textSegments = computed(() => {
+  if (mainViewMode.value === 'translated' && properties.item.translatedText) {
+    return parseTextSegments(
+      properties.item.translatedText,
+      properties.item.translatedUrlEntities
+    )
+  }
   return parseTextSegments(
-    properties.item.quotedTweet.fullText,
-    properties.item.quotedTweet.urlEntities
+    properties.item.fullText,
+    properties.item.urlEntities
   )
 })
+const quotedTextSegments = computed(() => {
+  const qt = properties.item.quotedTweet
+  if (!qt) return []
+  if (quotedViewMode.value === 'translated' && qt.translatedText) {
+    return parseTextSegments(qt.translatedText, qt.translatedUrlEntities)
+  }
+  return parseTextSegments(qt.fullText, qt.urlEntities)
+})
+
+/** 言語コードを日本語ラベルに変換する。未知のコードはそのまま返す。 */
+const LANGUAGE_LABELS: Record<string, string> = {
+  en: '英語',
+  ko: '韓国語',
+  zh: '中国語',
+  'zh-CN': '簡体中国語',
+  'zh-TW': '繁体中国語',
+  fr: 'フランス語',
+  de: 'ドイツ語',
+  es: 'スペイン語',
+  pt: 'ポルトガル語',
+  ru: 'ロシア語',
+  it: 'イタリア語',
+  ar: 'アラビア語',
+  th: 'タイ語',
+  vi: 'ベトナム語',
+  id: 'インドネシア語',
+  ja: '日本語',
+}
+
+/**
+ * 言語コードを日本語ラベルに変換する
+ * @param code - BCP47 言語コード
+ * @returns 日本語ラベル（未知のコードはそのまま返す）
+ */
+function formatLanguage(code: string | null): string {
+  if (!code) return '他言語'
+  return LANGUAGE_LABELS[code] ?? code
+}
 
 // ---- YouTube 埋め込み -------------------------------------------------------
 
@@ -442,6 +491,20 @@ async function onDeleteBookmark(account: string) {
           <span v-else>{{ seg.content }}</span>
         </template>
       </div>
+      <div v-if="item.translatedText" class="translation-toggle">
+        <span v-if="mainViewMode === 'translated'" class="translation-note">
+          {{ formatLanguage(item.sourceLanguage) }}から翻訳
+        </span>
+        <button
+          type="button"
+          class="translation-toggle-btn"
+          @click.stop="
+            mainViewMode =
+              mainViewMode === 'translated' ? 'original' : 'translated'
+          ">
+          {{ mainViewMode === 'translated' ? '元の言語を表示' : '翻訳を表示' }}
+        </button>
+      </div>
 
       <!-- YouTube 埋め込み -->
       <div v-if="youtubeEmbedUrl" class="embed-container">
@@ -592,6 +655,24 @@ async function onDeleteBookmark(account: string) {
             >
             <span v-else>{{ seg.content }}</span>
           </template>
+        </div>
+        <div
+          v-if="item.quotedTweet?.translatedText"
+          class="translation-toggle quoted-translation-toggle">
+          <span v-if="quotedViewMode === 'translated'" class="translation-note">
+            {{ formatLanguage(item.quotedTweet.sourceLanguage) }}から翻訳
+          </span>
+          <button
+            type="button"
+            class="translation-toggle-btn"
+            @click.stop="
+              quotedViewMode =
+                quotedViewMode === 'translated' ? 'original' : 'translated'
+            ">
+            {{
+              quotedViewMode === 'translated' ? '元の言語を表示' : '翻訳を表示'
+            }}
+          </button>
         </div>
         <!-- 引用ツイートのメディア -->
         <template v-for="(media, i) in item.quotedTweet.mediaItems" :key="i">
@@ -1385,5 +1466,43 @@ async function onDeleteBookmark(account: string) {
 
 .lightbox-close:hover {
   background: rgba(15, 20, 25, 0.9);
+}
+
+/* ============================================================
+   翻訳切替 UI
+   ============================================================ */
+.translation-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--color-text-secondary, #657786);
+}
+
+.translation-note {
+  font-size: 12px;
+}
+
+.translation-toggle-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent, #1da1f2);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.translation-toggle-btn:hover {
+  text-decoration: underline;
+}
+
+.quoted-translation-toggle {
+  font-size: 12px;
+}
+
+.quoted-translation-toggle .translation-toggle-btn {
+  font-size: 12px;
 }
 </style>


### PR DESCRIPTION
## Summary

- Twitter API のブックマーク取得レスポンスに含まれる Grok 翻訳テキスト (`grokTranslatedPostWithAvailability`) を crawler で抽出し DB に保存する
- viewer フロントエンドで翻訳付きツイートをデフォルトで翻訳表示し、「元の言語を表示 / 翻訳を表示」リンクで切り替えできるようにする
- 引用ツイートも親ツイートと独立して切り替え可能
- Twitter API の変更 (`screenName`/`name`/`profileImageUrl` が `user.legacy` から `user.core`/`user.avatar` に移動) に対応

## Changes

### shared

- `shared/src/schema.ts`: `tweets` テーブルに `translated_text`・`source_language`・`destination_language` カラム追加。`url_entities` テーブルに `kind` カラム追加（`'original'` / `'translated'`）
- 既存 DB 向けの `COLUMN_MIGRATIONS` と `applyColumnMigrations` 関数を追加
- `shared/src/types.ts`: `BookmarkItem` と `QuotedTweet` に翻訳 4 フィールドを追加

### crawler

- `crawler/src/infra/bookmarks-api.ts`:
  - `extractGrokTranslation` ヘルパを追加
  - Twitter API 変更対応: `screenName`/`name` を `user.core` から、`profileImageUrl` を `user.avatar` から取得（`user.legacy` をフォールバックとして保持）
- `crawler/src/infra/database.ts`: `applyColumnMigrations` 呼び出し追加・翻訳フィールドの upsert 対応

### viewer/backend

- `viewer/backend/src/infra/database.ts`: `applyColumnMigrations` 呼び出し追加・`getBookmarks` SELECT に翻訳フィールド追加

### viewer/frontend

- `viewer/frontend/src/components/BookmarkCard.vue`:
  - `mainViewMode` / `quotedViewMode` ref で表示モード管理
  - 翻訳あり時のみ「元の言語を表示 / 翻訳を表示」切替リンクを表示
  - `item` prop が切り替わったとき (`watch`) に表示モードをリセット（コンポーネント再利用時の状態残留を防止）

## Migration

既存 DB に対して crawler/viewer-backend 起動時に自動でカラム追加マイグレーションが適用される。

- Closes #100