### PR TITLE
fix(frontend): Service Worker の navigateFallback を廃止し NetworkFirst に変更

### DIFF
--- a/viewer/frontend/vite.config.ts
+++ b/viewer/frontend/vite.config.ts
@@ -35,11 +35,18 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // ナビゲーションフォールバックを有効にし、オフライン時でも SPA が動作するよう index.html を返す
-        // /api/* はサービスワーカーのフォールバック対象から除外する
-        navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api\//],
         runtimeCaching: [
+          {
+            // ナビゲーションリクエスト（ページ読み込み）は NetworkFirst にし、
+            // Cloudflare Access による JWT 検証・再認証が正しく動作するようにする
+            // オフライン時はキャッシュにフォールバックする
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'navigation-cache',
+              networkTimeoutSeconds: 3,
+            },
+          },
           {
             // Twitter 画像をキャッシュ（pbs.twimg.com）
             // 静的アセットルールより前に定義し、Twitter 画像が正しいキャッシュに格納されるようにする

--- a/viewer/frontend/vite.config.ts
+++ b/viewer/frontend/vite.config.ts
@@ -39,12 +39,16 @@ export default defineConfig({
           {
             // ナビゲーションリクエスト（ページ読み込み）は NetworkFirst にし、
             // Cloudflare Access による JWT 検証・再認証が正しく動作するようにする
-            // オフライン時はキャッシュにフォールバックする
+            // ネットワーク失敗時またはタイムアウト時はキャッシュにフォールバックする
             urlPattern: ({ request }) => request.mode === 'navigate',
             handler: 'NetworkFirst',
             options: {
               cacheName: 'navigation-cache',
               networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24, // 1 日
+              },
             },
           },
           {


### PR DESCRIPTION
## Summary

Cloudflare Access で保護された環境において、Service Worker の `navigateFallback` 設定が JWT 再認証を妨げ、API 呼び出しが 302 リダイレクトになる問題を修正する。

## 問題の原因

`vite.config.ts` の Workbox 設定で `navigateFallback: '/index.html'` が設定されていたため、Service Worker がナビゲーションリクエストをキャッシュの `index.html` で返していた。この結果、Cloudflare Access の JWT 期限切れ時にエッジを通過せず再認証が行われず、その後の API 呼び出しが 302 になり `NetworkError` が発生していた。

## 変更内容

- `navigateFallback: '/index.html'` と `navigateFallbackDenylist: [/^\/api\//]` を削除
- `runtimeCaching` に `request.mode === 'navigate'` を対象とした `NetworkFirst` ルールを追加
  - ページ読み込みのたびにネットワークリクエストが発生し、Cloudflare Access が JWT 検証・更新できる
  - JWT 期限切れの場合は Cloudflare Access のログインページへ正しくリダイレクトされる
  - `networkTimeoutSeconds: 3` を設定し、ネットワーク失敗時またはタイムアウト時はキャッシュにフォールバックする
  - `expiration` に件数上限（10 件）と有効期限（1 日）を設定し、Cache Storage の肥大化を防ぐ

## 影響範囲

- `viewer/frontend/vite.config.ts` のみ
- API 呼び出し (`/api/*`) には影響なし（`fetch()` は `mode: 'navigate'` にならないため）

## テスト方法

1. Cloudflare Access で保護された環境に本変更をデプロイ
2. ブラウザで Service Worker を登録した状態で JWT を期限切れにする
3. ページをリロードすると Cloudflare Access のログインページにリダイレクトされることを確認
4. 再認証後にページが正常に表示され、API 呼び出しが成功することを確認

- Closes #133