### PR TITLE
feat(viewer): 検索対象を拡張し、グループ単位で切り替えられる検索範囲ボタンを追加する

### DIFF
--- a/viewer/backend/src/infra/database.ts
+++ b/viewer/backend/src/infra/database.ts
@@ -9,14 +9,35 @@ import type {
 } from '@twitter-bookmark-hub/shared'
 import type { BookmarkItem, AccountInfo } from '../shared/types'
 
+/**
+ * 検索対象グループ。
+ * - `text`   : ツイート本文・翻訳テキスト
+ * - `card`   : カードタイトル・概要・URL
+ * - `url`    : URL エンティティ（展開済み URL・表示 URL）
+ * - `author` : 投稿者 @ハンドル・表示名
+ * - `quoted` : 引用ツイート本文・翻訳テキスト
+ */
+export type SearchInGroup = 'text' | 'card' | 'url' | 'author' | 'quoted'
+
+/** 全検索対象グループ（デフォルト値として使用） */
+const ALL_SEARCH_GROUPS: SearchInGroup[] = [
+  'text',
+  'card',
+  'url',
+  'author',
+  'quoted',
+]
+
 /** ブックマーク取得時のパラメータ */
 interface GetBookmarksParams {
   /** ページ番号 */
   page: number
   /** 1 ページあたりの件数 */
   limit: number
-  /** 検索クエリ（ツイート本文・カード情報・URL エンティティで部分一致） */
+  /** 検索クエリ */
   q?: string
+  /** 検索対象グループ（省略時は全グループを対象にする） */
+  searchIn?: SearchInGroup[]
   /** アカウントでフィルタ */
   account?: string
   /** ソートキー (bookmarked_at: ブックマーク初回発見日 / created_at: ツイート投稿日) */
@@ -220,20 +241,51 @@ export function getBookmarks(
   const bindValues: unknown[] = []
 
   if (q) {
-    // ツイート本文・カードタイトル・カード概要・カード URL・URL エンティティを対象に全文検索する
-    conditions.push(
-      '(t.full_text LIKE ? OR t.card_title LIKE ? OR t.card_description LIKE ? OR t.card_url LIKE ? OR t.card_vanity_url LIKE ? OR EXISTS (SELECT 1 FROM url_entities ue WHERE ue.tweet_id = t.tweet_id AND (ue.expanded_url LIKE ? OR ue.display_url LIKE ?)))'
+    const activeGroups = new Set<SearchInGroup>(
+      params.searchIn && params.searchIn.length > 0
+        ? params.searchIn
+        : ALL_SEARCH_GROUPS
     )
     const likeParam = `%${q}%`
-    bindValues.push(
-      likeParam,
-      likeParam,
-      likeParam,
-      likeParam,
-      likeParam,
-      likeParam,
-      likeParam
-    )
+    const clauses: string[] = []
+
+    if (activeGroups.has('text')) {
+      clauses.push('t.full_text LIKE ?', 't.translated_text LIKE ?')
+      bindValues.push(likeParam, likeParam)
+    }
+    if (activeGroups.has('card')) {
+      clauses.push(
+        't.card_title LIKE ?',
+        't.card_description LIKE ?',
+        't.card_url LIKE ?',
+        't.card_vanity_url LIKE ?'
+      )
+      bindValues.push(likeParam, likeParam, likeParam, likeParam)
+    }
+    if (activeGroups.has('url')) {
+      clauses.push(
+        'EXISTS (SELECT 1 FROM url_entities ue WHERE ue.tweet_id = t.tweet_id AND (ue.expanded_url LIKE ? OR ue.display_url LIKE ?))'
+      )
+      bindValues.push(likeParam, likeParam)
+    }
+    if (activeGroups.has('author')) {
+      // users テーブルはカウントクエリに JOIN されないためサブクエリで参照する
+      clauses.push(
+        'EXISTS (SELECT 1 FROM users u2 WHERE u2.user_id = t.user_id AND (u2.screen_name LIKE ? OR u2.user_name LIKE ?))'
+      )
+      bindValues.push(likeParam, likeParam)
+    }
+    if (activeGroups.has('quoted')) {
+      // 引用ツイートはカウントクエリに JOIN されないためサブクエリで参照する
+      clauses.push(
+        'EXISTS (SELECT 1 FROM tweets qt2 WHERE qt2.tweet_id = t.quoted_tweet_id AND (qt2.full_text LIKE ? OR qt2.translated_text LIKE ?))'
+      )
+      bindValues.push(likeParam, likeParam)
+    }
+
+    if (clauses.length > 0) {
+      conditions.push(`(${clauses.join(' OR ')})`)
+    }
   }
   if (account) {
     // EXISTS サブクエリでフィルタすることで、メインの bookmarks JOIN の集計

--- a/viewer/backend/src/infra/database.ts
+++ b/viewer/backend/src/infra/database.ts
@@ -15,7 +15,7 @@ interface GetBookmarksParams {
   page: number
   /** 1 ページあたりの件数 */
   limit: number
-  /** 検索クエリ（ツイート本文で部分一致） */
+  /** 検索クエリ（ツイート本文・カード情報・URL エンティティで部分一致） */
   q?: string
   /** アカウントでフィルタ */
   account?: string
@@ -220,12 +220,20 @@ export function getBookmarks(
   const bindValues: unknown[] = []
 
   if (q) {
-    // ツイート本文・カードタイトル・カード概要を対象に全文検索する
+    // ツイート本文・カードタイトル・カード概要・カード URL・URL エンティティを対象に全文検索する
     conditions.push(
-      '(t.full_text LIKE ? OR t.card_title LIKE ? OR t.card_description LIKE ?)'
+      '(t.full_text LIKE ? OR t.card_title LIKE ? OR t.card_description LIKE ? OR t.card_url LIKE ? OR t.card_vanity_url LIKE ? OR EXISTS (SELECT 1 FROM url_entities ue WHERE ue.tweet_id = t.tweet_id AND (ue.expanded_url LIKE ? OR ue.display_url LIKE ?)))'
     )
     const likeParam = `%${q}%`
-    bindValues.push(likeParam, likeParam, likeParam)
+    bindValues.push(
+      likeParam,
+      likeParam,
+      likeParam,
+      likeParam,
+      likeParam,
+      likeParam,
+      likeParam
+    )
   }
   if (account) {
     // EXISTS サブクエリでフィルタすることで、メインの bookmarks JOIN の集計

--- a/viewer/backend/src/routes/bookmarks.ts
+++ b/viewer/backend/src/routes/bookmarks.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type Database from 'better-sqlite3'
 import { getBookmarks } from '../infra/database'
+import type { SearchInGroup } from '../infra/database'
 import type { BookmarksResponse } from '../shared/types'
 import { CRAWLER_URL } from '../shared/config'
 
@@ -45,10 +46,28 @@ export function bookmarksRoute(db: Database.Database): Hono {
     const rawTag = c.req.query('tag')
     const tag: string | undefined = rawTag === '' ? undefined : rawTag
 
+    const VALID_GROUPS = new Set<SearchInGroup>([
+      'text',
+      'card',
+      'url',
+      'author',
+      'quoted',
+    ])
+    const rawSearchIn = c.req.query('search_in')
+    const searchIn: SearchInGroup[] | undefined =
+      rawSearchIn && rawSearchIn !== ''
+        ? rawSearchIn
+            .split(',')
+            .filter((g): g is SearchInGroup =>
+              VALID_GROUPS.has(g as SearchInGroup)
+            )
+        : undefined
+
     const result = getBookmarks(db, {
       page,
       limit,
       q,
+      searchIn,
       account,
       sort,
       sortBy,

--- a/viewer/frontend/src/App.vue
+++ b/viewer/frontend/src/App.vue
@@ -8,6 +8,7 @@ import CrawlStatus from './components/CrawlStatus.vue'
 import AccountFilter from './components/AccountFilter.vue'
 import CategoryFilter from './components/CategoryFilter.vue'
 import BookmarkList from './components/BookmarkList.vue'
+import SearchOptions from './components/SearchOptions.vue'
 import Settings from './views/Settings.vue'
 
 const {
@@ -15,6 +16,7 @@ const {
   selectedCategory,
   selectedTag,
   searchQuery,
+  searchIn,
   sortBy,
   sortOrder,
   items,
@@ -243,6 +245,8 @@ function onBookmarkDeleted(payload: { tweetId: string; account: string }) {
             type="text"
             class="search-input"
             placeholder="ブックマークを検索" />
+          <!-- 検索対象グループ選択 -->
+          <SearchOptions v-model="searchIn" />
           <!-- ソートキー選択 -->
           <select v-model="sortBy" class="sort-select" title="ソート条件">
             <option value="bookmarked_at">発見日</option>

--- a/viewer/frontend/src/api.ts
+++ b/viewer/frontend/src/api.ts
@@ -51,6 +51,21 @@ async function throwResponseError(
 }
 
 /**
+ * 検索対象グループ。
+ * backend の SearchInGroup と同一の値セット。
+ */
+export type SearchInGroup = 'text' | 'card' | 'url' | 'author' | 'quoted'
+
+/** 全検索対象グループ */
+export const ALL_SEARCH_GROUPS: SearchInGroup[] = [
+  'text',
+  'card',
+  'url',
+  'author',
+  'quoted',
+]
+
+/**
  * ブックマーク一覧を取得する
  * @param params - 検索パラメータ
  * @returns ブックマークレスポンス
@@ -59,6 +74,8 @@ export async function fetchBookmarks(params: {
   page?: number
   limit?: number
   q?: string
+  /** 検索対象グループ（省略時は全グループ） */
+  searchIn?: SearchInGroup[]
   account?: string
   sort?: 'asc' | 'desc'
   sortBy?: 'bookmarked_at' | 'created_at'
@@ -70,6 +87,9 @@ export async function fetchBookmarks(params: {
   if (params.page != null) query.set('page', String(params.page))
   if (params.limit != null) query.set('limit', String(params.limit))
   if (params.q) query.set('q', params.q)
+  if (params.searchIn && params.searchIn.length > 0) {
+    query.set('search_in', params.searchIn.join(','))
+  }
   if (params.account) query.set('account', params.account)
   if (params.sort) query.set('sort', params.sort)
   if (params.sortBy) query.set('sort_by', params.sortBy)

--- a/viewer/frontend/src/components/SearchOptions.vue
+++ b/viewer/frontend/src/components/SearchOptions.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import type { SearchInGroup } from '../api'
+import { ALL_SEARCH_GROUPS } from '../api'
+
+const properties = defineProps<{
+  /** 現在有効な検索対象グループ */
+  modelValue: SearchInGroup[]
+}>()
+
+const emit = defineEmits<{
+  /** 検索対象グループが変更された */
+  'update:modelValue': [groups: SearchInGroup[]]
+}>()
+
+/** グループ名とラベルのマッピング */
+const GROUP_LABELS: Record<SearchInGroup, string> = {
+  text: 'ツイート本文',
+  card: 'カード情報',
+  url: 'リンク先 URL',
+  author: '投稿者名',
+  quoted: '引用ツイート',
+}
+
+/** ドロップダウンの開閉状態 */
+const open = ref(false)
+/** ドロップダウンのルート要素（クリックアウト判定用） */
+const root = ref<HTMLElement | null>(null)
+
+/**
+ * グループのチェック状態を切り替える。
+ * 全グループが OFF になる操作は無視する。
+ * @param group - 切り替え対象のグループ
+ */
+function toggle(group: SearchInGroup) {
+  const current = properties.modelValue
+  const next = current.includes(group)
+    ? current.filter((g) => g !== group)
+    : [...current, group]
+  if (next.length === 0) return
+  emit('update:modelValue', next)
+}
+
+/**
+ * ドロップダウン外クリック時に閉じる。
+ * @param event - マウスイベント
+ */
+function onClickOutside(event: MouseEvent) {
+  if (root.value && !root.value.contains(event.target as Node)) {
+    open.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onClickOutside)
+})
+onUnmounted(() => {
+  document.removeEventListener('mousedown', onClickOutside)
+})
+
+/** 全グループが有効かどうか */
+const isAllActive = () =>
+  ALL_SEARCH_GROUPS.every((g) => properties.modelValue.includes(g))
+</script>
+
+<template>
+  <div ref="root" class="search-options">
+    <button
+      class="options-btn"
+      :class="{ active: !isAllActive(), open }"
+      :title="open ? '検索対象を閉じる' : '検索対象を絞り込む'"
+      :aria-expanded="open"
+      @click="open = !open">
+      <span class="options-icon" aria-hidden="true">⊟</span>
+    </button>
+
+    <div v-if="open" class="dropdown" role="group" aria-label="検索対象">
+      <label v-for="group in ALL_SEARCH_GROUPS" :key="group" class="option-row">
+        <input
+          type="checkbox"
+          :checked="modelValue.includes(group)"
+          @change="toggle(group)" />
+        <span class="option-label">{{ GROUP_LABELS[group] }}</span>
+      </label>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.search-options {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.options-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    color 0.2s,
+    background 0.2s;
+}
+
+.options-btn:hover,
+.options-btn.open {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* 一部グループが無効の場合はアクセント色で強調 */
+.options-btn.active {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: rgba(29, 155, 240, 0.1);
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 100;
+  min-width: 160px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 8px 0;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.option-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.option-row:hover {
+  background: rgba(239, 243, 244, 0.08);
+}
+
+.option-row input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.option-label {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  user-select: none;
+}
+</style>

--- a/viewer/frontend/src/components/SearchOptions.vue
+++ b/viewer/frontend/src/components/SearchOptions.vue
@@ -71,7 +71,24 @@ const isAllActive = () =>
       :title="open ? '検索対象を閉じる' : '検索対象を絞り込む'"
       :aria-expanded="open"
       @click="open = !open">
-      <span class="options-icon" aria-hidden="true">⊟</span>
+      <!-- スライダーアイコン（検索対象の絞り込みを表す） -->
+      <svg
+        aria-hidden="true"
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.6"
+        stroke-linecap="round">
+        <line x1="2" y1="4" x2="14" y2="4" />
+        <line x1="2" y1="8" x2="14" y2="8" />
+        <line x1="2" y1="12" x2="14" y2="12" />
+        <circle cx="5" cy="4" r="1.6" fill="currentColor" stroke="none" />
+        <circle cx="10" cy="8" r="1.6" fill="currentColor" stroke="none" />
+        <circle cx="7" cy="12" r="1.6" fill="currentColor" stroke="none" />
+      </svg>
+      <span class="options-label">検索範囲</span>
     </button>
 
     <div v-if="open" class="dropdown" role="group" aria-label="検索対象">
@@ -95,19 +112,24 @@ const isAllActive = () =>
 .options-btn {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
+  gap: 5px;
+  flex-shrink: 0;
+  padding: 7px 10px;
   border: 1px solid var(--color-border);
-  border-radius: 50%;
+  border-radius: 9999px;
   background: transparent;
   color: var(--color-text-secondary);
-  font-size: 16px;
+  font-size: 13px;
   cursor: pointer;
+  white-space: nowrap;
   transition:
     border-color 0.2s,
     color 0.2s,
     background 0.2s;
+}
+
+.options-label {
+  font-size: 13px;
 }
 
 .options-btn:hover,

--- a/viewer/frontend/src/composables/useBookmarks.ts
+++ b/viewer/frontend/src/composables/useBookmarks.ts
@@ -1,6 +1,6 @@
 import { ref, watch, watchEffect, onScopeDispose } from 'vue'
-import { fetchBookmarks } from '../api'
-import type { BookmarkItem } from '../api'
+import { fetchBookmarks, ALL_SEARCH_GROUPS } from '../api'
+import type { BookmarkItem, SearchInGroup } from '../api'
 
 /**
  * 指定した関数を delay ミリ秒デバウンスするユーティリティ。
@@ -32,6 +32,23 @@ function debounce<T extends () => void>(
 /** localStorage のキー定数 */
 const LS_SORT_BY = 'bookmark-sort-by'
 const LS_SORT_ORDER = 'bookmark-sort-order'
+const LS_SEARCH_IN = 'bookmark-search-in'
+
+/**
+ * localStorage から検索対象グループを復元する。
+ * 不正な値は無視し、空の場合は全グループを返す。
+ * @returns 有効な SearchInGroup の配列
+ */
+function loadSearchIn(): SearchInGroup[] {
+  const raw = localStorage.getItem(LS_SEARCH_IN)
+  if (!raw) return [...ALL_SEARCH_GROUPS]
+  const parsed = raw
+    .split(',')
+    .filter((g): g is SearchInGroup =>
+      ALL_SEARCH_GROUPS.includes(g as SearchInGroup)
+    )
+  return parsed.length > 0 ? parsed : [...ALL_SEARCH_GROUPS]
+}
 
 /**
  * ブックマーク一覧の取得・無限スクロール・フィルタリングを管理する composable。
@@ -46,6 +63,8 @@ export function useBookmarks() {
   const searchQuery = ref('')
   /** 検索クエリのデバウンス済み値（200ms 遅延）。watchEffect はこちらを追跡する */
   const debouncedSearchQuery = ref('')
+  /** 検索対象グループ（localStorage から復元） */
+  const searchIn = ref<SearchInGroup[]>(loadSearchIn())
 
   /** ソートキー（localStorage から復元） */
   const rawSortBy = localStorage.getItem(LS_SORT_BY)
@@ -64,6 +83,10 @@ export function useBookmarks() {
   /** sortOrder 変更時に localStorage へ保存 */
   watch(sortOrder, (val) => {
     localStorage.setItem(LS_SORT_ORDER, val)
+  })
+  /** searchIn 変更時に localStorage へ保存 */
+  watch(searchIn, (val) => {
+    localStorage.setItem(LS_SEARCH_IN, val.join(','))
   })
 
   /** 検索クエリ変更時に 200ms デバウンスして debouncedSearchQuery を更新する */
@@ -104,6 +127,7 @@ export function useBookmarks() {
       sort: sortOrder.value,
       sortBy: sortBy.value,
       ...(debouncedSearchQuery.value ? { q: debouncedSearchQuery.value } : {}),
+      ...(debouncedSearchQuery.value ? { searchIn: searchIn.value } : {}),
       ...(selectedAccount.value ? { account: selectedAccount.value } : {}),
       ...(selectedCategory.value === null
         ? {}
@@ -224,6 +248,7 @@ export function useBookmarks() {
     selectedCategory,
     selectedTag,
     searchQuery,
+    searchIn,
     sortBy,
     sortOrder,
     items,


### PR DESCRIPTION
## 概要

ブックマーク検索の対象フィールドを大幅に拡張し、URL・投稿者名・引用ツイートでも検索できるようにします。また検索バーに「検索範囲」ボタンを追加し、検索対象グループをユーザーが任意に切り替えられるようにします。

---

## 変更内容

### Backend

#### 検索対象の拡張（`GET /api/bookmarks?q=`）

| カラム | 説明 | 変更前 |
|--------|------|--------|
| `tweets.full_text` | ツイート本文 | ✅ |
| `tweets.translated_text` | 翻訳テキスト | ❌ → ✅ |
| `tweets.card_title` | カードタイトル | ✅ |
| `tweets.card_description` | カード概要 | ✅ |
| `tweets.card_url` | カード URL | ❌ → ✅ |
| `tweets.card_vanity_url` | カード表示用 URL | ❌ → ✅ |
| `url_entities.expanded_url` | t.co の展開済み URL | ❌ → ✅ |
| `url_entities.display_url` | t.co の表示用 URL | ❌ → ✅ |
| `users.screen_name` | 投稿者 @ハンドル | ❌ → ✅ |
| `users.user_name` | 投稿者表示名 | ❌ → ✅ |
| 引用ツイート `full_text` | 引用元ツイート本文 | ❌ → ✅ |
| 引用ツイート `translated_text` | 引用元ツイート翻訳テキスト | ❌ → ✅ |

`users` テーブルと引用ツイートはカウントクエリに JOIN されないため、EXISTS サブクエリ経由で参照します。検索条件はグループごとに `clauses.push()` で個別追加する方式で、プレースホルダ数の不整合が生じにくい構造です。

#### 検索対象グループの指定（`search_in` クエリパラメータ）

`?search_in=text,author` のようにカンマ区切りで検索対象グループを指定できます。省略時は全グループが対象です。

| グループ | 対象フィールド |
|---------|--------------|
| `text` | ツイート本文・翻訳テキスト |
| `card` | カードタイトル・概要・URL |
| `url` | URL エンティティ（展開済み URL・表示 URL） |
| `author` | 投稿者 @ハンドル・表示名 |
| `quoted` | 引用ツイート本文・翻訳テキスト |

### Frontend

- 検索ボックス横に「検索範囲」ボタンを追加。スライダー SVG アイコン + テキストラベルで検索に関するコントロールであることを明示
- クリックでドロップダウンが開き、各グループのチェックボックスで検索対象を絞り込める
- 選択状態は localStorage に保存され、ページ再読み込み後も維持される
- 全グループ以外が選択されている場合はボタンがアクセント色で強調表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)