### PR TITLE
fix: book000 reusable workflowのdigest指定をmasterに変更し、docker.ymlの全ジョブにallow-unsafe-pr-checkoutを設定する

### DIFF
--- a/.github/workflows/add-reviewer.yml
+++ b/.github/workflows/add-reviewer.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   add-reviewer:
     name: Add reviewer
-    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,7 +85,7 @@ jobs:
     name: Docker CI (crawler)
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    uses: book000/templates/.github/workflows/reusable-docker.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [
@@ -101,13 +101,14 @@ jobs:
     name: Docker CI (viewer)
     needs: docker-ci-crawler
     if: always() && needs.docker-ci-crawler.result == 'success'
-    uses: book000/templates/.github/workflows/reusable-docker.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [
           { imageName: "tomacheese/twitter-bookmark-hub-viewer", context: ".", file: "viewer/Dockerfile", packageName: "twitter-bookmark-hub-backend" }
         ]
       # registry: registry.hub.docker.com # default: ghcr.io
+      allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -116,13 +117,14 @@ jobs:
     name: Docker CI (analyzer)
     needs: docker-ci-viewer
     if: always() && needs.docker-ci-viewer.result == 'success'
-    uses: book000/templates/.github/workflows/reusable-docker.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [
           { imageName: "tomacheese/twitter-bookmark-hub-analyzer", context: ".", file: "analyzer/Dockerfile", packageName: "twitter-bookmark-hub-analyzer" }
         ]
       # registry: registry.hub.docker.com # default: ghcr.io
+      allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   node-ci:
     name: Node CI
-    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@a8b7f3c4f10d3da67893d91f84f8a019bf79ed4d # master
+    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@master
     with:
       directorys: "crawler, viewer/backend, viewer/frontend, analyzer"
       lock-path: "pnpm-lock.yaml"


### PR DESCRIPTION
## 概要

Renovate が book000/templates 参照の digest 固定を自動更新し続けていたため、
book000/book000#124 のロールアウト対応（`@master` 参照への変更）を再適用します。

あわせて、`docker.yml` の `docker-ci-viewer` / `docker-ci-analyzer` ジョブに
`allow-unsafe-pr-checkout` が未設定だったため追加しています
（`docker-ci-crawler` ジョブには既に設定済みでした）。

## 背景

book000/templates#432 の Renovate 設定バグにより、本リポジトリを含む複数リポジトリで
一度適用した `@master` 化が digest 固定へ巻き戻されていました。
book000/templates#434 で Renovate 設定は修正済みですが、既に digest 固定された参照は
そのまま更新が継続してしまうため、本 PR で改めて `@master` 参照へ戻します。

Refs: book000/book000#124
Refs: book000/templates#432
Refs: book000/templates#434