### PR TITLE
chore: エージェント向けドキュメントを整理し CLAUDE.md と copilot-instructions.md に統一

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,82 +1,35 @@
 # GitHub Copilot Instructions
 
+このファイルは GitHub Copilot のコードレビュー機能向けの指示です。開発手順の詳細は `CLAUDE.md` を参照してください。ここではレビュー時に重点確認すべき点に絞ります。
+
 ## プロジェクト概要
-- 目的: 複数の Twitter/X アカウントのブックマークを自動収集し、一元的に閲覧する
-- 主な機能: マルチアカウント対応ブックマーク収集、SQLite 保存、Twitter 風 Web UI での閲覧
-- 対象ユーザー: 複数の Twitter アカウントを持つ開発者
 
-## リポジトリ構成
-- `crawler/` — ブックマーク収集サービス（Node.js + Hono + SQLite）
-- `viewer/backend/` — 閲覧 API サーバー（Node.js + Hono + SQLite）
-- `viewer/frontend/` — Web UI（Vue 3 + Vite）
-- `compose.yaml` — Docker Compose によるサービス起動定義
+複数の Twitter/X アカウントのブックマークを収集し、Twitter 風 Web UI で閲覧するアプリ。TypeScript の pnpm workspace モノレポで、`crawler`（収集）・`viewer/backend`（API）・`viewer/frontend`（Vue 3 UI）・`analyzer`（任意のタグ/カテゴリ分類）・`shared`（共有型・SQLite DDL）で構成される。
 
-## 共通ルール
-- 会話は日本語で行う。
-- PR とコミットは Conventional Commits に従う。
-- 日本語と英数字の間には半角スペースを入れる。
-- エラーメッセージは英語で記載する。
+## 強制されている規約（lint で検査）
 
-## 技術スタック
-- 言語: TypeScript（crawler・backend）、Vue 3 + TypeScript（frontend）
-- ランタイム: Node.js (v24)
-- パッケージマネージャー: pnpm
-- 主要ライブラリ:
-  - crawler: `twitter-openapi-typescript`, `@the-convocation/twitter-scraper`, `cycletls`, `better-sqlite3`, `hono`
-  - backend: `better-sqlite3`, `hono`
-  - frontend: `vue`, `vite`
+各パッケージの `pnpm lint` は Prettier チェック・ESLint・`tsc --noEmit` を実行する。以下は自動検査されるため、レビューでは lint に任せてよい:
 
-## コーディング規約
-- フォーマット: Prettier
-- Lint: ESLint (`@book000/eslint-config`)
-- 関数・インターフェースには日本語で JSDoc を記載する。
-- TypeScript の `skipLibCheck` は使用しない。
+- Prettier: セミコロンなし（`semi: false`）、シングルクォート、`printWidth: 80`、末尾カンマは ES5。
+- ESLint: `@book000/eslint-config`。
+- 型チェック: `tsc --noEmit`。`skipLibCheck` を `true` にする変更は**必ず指摘する**（このリポジトリでは禁止）。
 
-## 開発コマンド
+## レビュー時の重点確認
 
-### crawler
-```bash
-cd crawler
-pnpm install
-pnpm start   # 実行
-pnpm lint    # Lint チェック
-pnpm fix     # 自動修正
-```
+- **SQL インジェクション**: DB クエリはパラメータ化する。ソート・オーダー・検索対象などユーザー入力に基づく識別子はホワイトリストで検証する（`viewer/backend/src/infra/database.ts` 参照）。文字列連結でクエリを組み立てる変更は指摘する。
+- **認証・機密情報**: `data/config.json`（Twitter 認証情報）・`data/cookies-*.json`・`.env`・`data/db.sqlite` をコミットに含めていないか。Cookie・トークン・パスワードをログ出力していないか。
+- **エラーハンドリング**: crawler の認証（`infra/auth.ts` の戦略ローテーション）・レートリミット（`shared/retry.ts` の 429/403 待機）で、失敗時のリトライ・待機が握り潰されていないか。
+- **並行処理**: `viewer/frontend` の `useBookmarks` は並行フェッチの競合を cancel フラグで防いでいる。フェッチ結果の反映順序を壊す変更に注意する。
+- **外部サービス連携**: analyzer は任意機能。`ANALYZER_URL` 未設定時に例外を投げず握り潰す設計（crawler・viewer/backend のプロキシ）を壊していないか。
+- **ドキュメント整合性**: 環境変数・API・DB スキーマ・サービス構成を変更した場合、`README.md` と `CLAUDE.md` の該当箇所も更新されているか。
 
-### viewer/backend
-```bash
-cd viewer/backend
-pnpm install
-pnpm start   # 実行
-pnpm lint    # Lint チェック
-pnpm fix     # 自動修正
-```
+## フラグすべきでない既知パターン（誤検知防止）
 
-### viewer/frontend
-```bash
-cd viewer/frontend
-pnpm install
-pnpm dev     # 開発サーバー起動
-pnpm build   # プロダクションビルド
-pnpm lint    # Lint チェック
-pnpm fix     # 自動修正
-```
+- **日本語のコメント・JSDoc**: 関数・インターフェースの JSDoc とコード内コメントは日本語で書く方針。エラーメッセージのみ英語。日本語コメントを英語化する提案はしない。
+- **日本語と英数字の間の半角スペース**: 意図的な表記ルール。除去を提案しない。
+- **analyzer 用テーブルの存在チェック**: `viewer/backend` が `tweet_tags`・`tweet_categories` 等の存在を実行時に確認してクエリを分岐するのは、analyzer がオプショナルで当該テーブルが無い場合があるため。冗長・デッドコードとして指摘しない。
+- **`better-sqlite3` の同期 API**: 同期呼び出しは意図的（このプロジェクトの想定負荷では問題ない）。async 化を一律に提案しない。
 
-### Docker Compose（全サービス起動）
-```bash
-docker compose up -d
-```
+## コミット / PR
 
-## セキュリティ / 機密情報
-- `data/config.json` に含まれる Twitter 認証情報（パスワード・OTP シークレット）はコミットしない。
-- `data/cookies-*.json` の Cookie ファイルはコミットしない。
-- `.env` に含まれる環境変数はコミットしない（`.env.example` のみコミット可）。
-
-## ドキュメント更新
-- `README.md`（仕様変更・環境変数追加時）
-
-## リポジトリ固有
-- Docker Compose での実行を主とする（`docker compose up -d`）。
-- データは `data/` ディレクトリに保存される（`.gitignore` 済み）。
-- crawler は HTTP API（port 3001）を持ち、viewer backend からクロール状態を参照する。
-- viewer は port 3000 で Web UI を提供する。
+- Conventional Commits に従う。description は日本語。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@
 | `crawler` | 3001 | 全アカウントのブックマークを定期取得し SQLite に保存する HTTP API サービス |
 | `viewer/backend` | 3000 | 収集済みブックマークを提供する API サーバー。フロントエンドの静的ファイルも配信 |
 | `viewer/frontend` | - | Vue 3 + Vite で構築した Twitter 風 Web UI（本番ビルドは backend に同梱） |
-| `shared` | - | crawler・backend 間の共有型定義・SQLite スキーマ DDL |
+| `analyzer` | 3002 | （任意）収集済みツイートを kuromoji で形態素解析し、タグ抽出・カテゴリ自動分類を行う HTTP API サービス。Docker Compose の `analyzer` プロファイルでのみ起動する |
+| `shared` | - | crawler・backend・analyzer 間の共有型定義・SQLite スキーマ DDL |
 
 ## リポジトリ構成
 
@@ -37,8 +38,23 @@ crawler/
 shared/
   src/
     schema.ts           # SQLite DDL 定数 (SCHEMA_DDL: CREATE TABLE 文)
-    types.ts            # 共有型 (BookmarkItem, MediaItem, UrlEntity 等)
+    types.ts            # 共有型 (BookmarkItem, MediaItem, UrlEntity, FeaturesResponse 等)
     index.ts            # エクスポート
+
+analyzer/                 # (任意) 形態素解析によるタグ抽出・カテゴリ分類サービス
+  src/
+    core/
+      tagger.ts         # kuromoji トークナイザ初期化・名詞抽出 (initTokenizer, extractNouns)
+      categorizer.ts    # タグとカテゴリキーワードの照合 (matchCategories)
+    infra/
+      database.ts       # DB 操作 (タグ・カテゴリの保存/取得、IDF ノイズプルーニング)
+    routes/
+      analyze.ts        # POST /analyze, POST /analyze/prune-noise
+      categories.ts     # GET/POST /categories, PUT/DELETE /categories/:id
+      tags.ts           # GET /tags
+    main.ts             # エントリポイント (DB 初期化・kuromoji 初期化・サーバー起動)
+    server.ts           # Hono サーバー設定 (/health + 各ルート)
+  Dockerfile            # analyzer コンテナ (kuromoji 辞書同梱)
 
 viewer/
   backend/
@@ -61,10 +77,15 @@ viewer/
         BookmarkCard.vue    # ツイートカード (テキスト・メディア・引用ツイート等)
         BookmarkList.vue    # ブックマーク一覧 + ページネーション
         CrawlStatus.vue     # ヘッダー内クロール状態表示・手動実行ボタン
+        CategoryFilter.vue  # (analyzer 有効時) カテゴリ絞り込み
+        CategoryManager.vue # (analyzer 有効時) カテゴリの作成・編集・削除 UI
+        SearchOptions.vue   # 検索対象グループ (text/card/url/author/quoted) の選択
       composables/
         useAccounts.ts      # アカウント一覧の状態管理
         useBookmarks.ts     # ブックマーク取得・ページネーション・ソート
         useCrawlStatus.ts   # クロール状態ポーリング (10 秒間隔)
+        useCategories.ts    # (analyzer 有効時) カテゴリ一覧・管理
+        useFeatures.ts      # 機能フラグ取得 (GET /api/features、analyzer 有効判定)
       api.ts            # バックエンド API クライアント
       App.vue           # ルートコンポーネント (レイアウト・ルーティング)
       main.ts           # Vue アプリ初期化
@@ -80,9 +101,10 @@ compose.yaml            # Docker Compose 定義
 | 言語 | TypeScript |
 | ランタイム | Node.js v24 |
 | パッケージマネージャー | pnpm (workspace モノレポ) |
-| crawler / backend フレームワーク | Hono |
+| crawler / backend / analyzer フレームワーク | Hono |
 | DB | better-sqlite3 (SQLite、WAL モード) |
 | frontend フレームワーク | Vue 3 Composition API + Vite |
+| 形態素解析 (analyzer) | @patdx/kuromoji (日本語)、stopword (英語ストップワード) |
 | Twitter API | twitter-openapi-typescript, @the-convocation/twitter-scraper |
 | TLS フィンガープリント偽装 | cycletls (Chrome 120 偽装) |
 | Lint | ESLint (`@book000/eslint-config`) + Prettier |
@@ -113,11 +135,16 @@ CI (`nodejs-ci.yml`) は `crawler`、`viewer/backend`、`viewer/frontend`、`ana
 # Docker Compose で全サービス起動（推奨）
 docker compose up -d
 
+# analyzer（任意機能）も起動する場合は analyzer プロファイルを有効にする
+#   .env に ANALYZER_URL=http://analyzer:3002 を設定してから:
+docker compose --profile analyzer up -d
+
 # 個別起動（開発時）
 cd crawler && pnpm start          # ポート 3001
 cd viewer/backend && pnpm start   # ポート 3000 (Docker Compose では外部公開)
 cd viewer/frontend && pnpm dev    # Vite 開発サーバー (API は localhost:3000 にプロキシ)
 cd viewer/frontend && pnpm build  # プロダクションビルド (dist/ に出力)
+cd analyzer && pnpm start         # ポート 3002 (任意機能)
 ```
 
 ### テスト環境の構築
@@ -218,28 +245,38 @@ config.json (アカウント設定)
       ↓
   crawler (port 3001)
   ├── scheduler.ts  ← cron (CRAWL_SCHEDULE)
-  ├── server.ts     ← GET /health, POST /crawl, GET /crawl/status
+  ├── server.ts     ← GET /health, POST/GET /crawl(/status), POST/DELETE /bookmarks
   └── core/crawler.ts
       ├── infra/auth.ts        ← Cookie 取得 (env → ファイルキャッシュ → ライブログイン)
       ├── infra/bookmarks-api.ts ← twitter-openapi-typescript + CycleTLS
-      └── infra/database.ts    → data/db.sqlite (WAL モード)
+      ├── infra/database.ts    → data/db.sqlite (WAL モード)
+      └── (ANALYZER_URL 設定時) → analyzer /analyze・/analyze/prune-noise を呼び出し
                                          ↓
                               viewer/backend (port 3000)
                               ├── GET /api/accounts
                               ├── GET /api/bookmarks (ページネーション・検索・フィルタ)
                               ├── GET /api/crawl/status
                               ├── POST /api/crawl/trigger → crawler /crawl
+                              ├── GET /api/features (analyzer 有効判定)
+                              ├── /api/categories, /api/tags → analyzer へプロキシ (ANALYZER_URL 設定時)
                               └── static /public (Vue 3 SPA)
                                          ↓
                               viewer/frontend (Vue 3)
                               ├── useBookmarks.ts  ← GET /api/bookmarks
                               ├── useAccounts.ts   ← GET /api/accounts
-                              └── useCrawlStatus.ts ← GET /api/crawl/status (10 秒ポーリング)
+                              ├── useCrawlStatus.ts ← GET /api/crawl/status (10 秒ポーリング)
+                              ├── useFeatures.ts   ← GET /api/features
+                              └── useCategories.ts ← GET/POST/PUT/DELETE /api/categories (analyzer 有効時)
+
+  analyzer (port 3002、任意 / ANALYZER_URL 設定時のみ)
+  ├── core/tagger.ts     ← kuromoji 形態素解析でツイート本文から名詞タグを抽出
+  ├── core/categorizer.ts ← タグとカテゴリキーワードを照合しカテゴリを付与
+  └── infra/database.ts  → 同一 data/db.sqlite の tags/tweet_tags/categories/tweet_categories
 ```
 
 ## DB スキーマ
 
-SQLite。6 テーブル構成。DDL は `shared/src/schema.ts` の `SCHEMA_DDL` 定数に定義されている。WAL モード・外部キー制約・ビジータイムアウト 5 秒で初期化される。
+SQLite。11 テーブル構成（うち `tags` / `tweet_tags` / `categories` / `tweet_categories` の 4 テーブルは analyzer 機能用で、analyzer 未使用時は空のまま）。DDL は `shared/src/schema.ts` の `SCHEMA_DDL` 定数に定義されている。WAL モード・外部キー制約・ビジータイムアウト 5 秒で初期化される。viewer/backend は analyzer 用テーブルの存在を実行時にチェックし、無い場合はタグ・カテゴリ関連のクエリを省略する。
 
 | テーブル | 主キー | 説明 |
 |---------|--------|------|
@@ -249,6 +286,11 @@ SQLite。6 テーブル構成。DDL は `shared/src/schema.ts` の `SCHEMA_DDL` 
 | `url_entities` | `id` (INTEGER) | t.co URL → 展開 URL マッピング |
 | `bookmarks` | `(tweet_id, account_username)` | どのアカウントがいつブックマークしたか |
 | `crawl_jobs` | `id` (INTEGER) | クロール実行履歴・ステータス |
+| `crawl_account_results` | `id` (INTEGER) | クロールジョブ内のアカウント別結果 (成功/失敗・エラー種別・取得件数) |
+| `tags` | `id` (INTEGER) | (analyzer) 抽出されたタグ名 (UNIQUE) |
+| `tweet_tags` | `(tweet_id, tag_id)` | (analyzer) ツイートとタグの関連 |
+| `categories` | `id` (INTEGER) | (analyzer) カテゴリ定義 (name・color・keywords JSON) |
+| `tweet_categories` | `(tweet_id, category_id)` | (analyzer) ツイートとカテゴリの関連 (confidence 付き) |
 
 ### bookmarks テーブルの重要フィールド
 
@@ -304,6 +346,8 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 | GET | `/api/bookmarks` | ブックマーク一覧 (下記クエリパラメータ参照) |
 | GET | `/api/crawl/status` | 最新クロールジョブの状態 |
 | POST | `/api/crawl/trigger` | クロールを手動実行 (crawler の /crawl を呼び出し) |
+| GET | `/api/features` | 有効な機能フラグを返す (`{analyzer: boolean}`。`ANALYZER_URL` の有無で判定) |
+| ALL | `/api/categories`, `/api/categories/:id`, `/api/tags` | analyzer へのプロキシ。`ANALYZER_URL` 未設定時は 404 を返す (10 秒タイムアウト) |
 
 ### GET /api/bookmarks のクエリパラメータ
 
@@ -312,11 +356,14 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 | `page` | `1` | ページ番号 |
 | `limit` | `20` | 1 ページあたり件数 (最大 100) |
 | `q` | - | 全文検索クエリ |
+| `search_in` | 全グループ | 検索対象グループをカンマ区切りで指定 (`text` / `card` / `url` / `author` / `quoted`) |
 | `account` | - | アカウント名でフィルタ |
+| `category` | - | カテゴリ ID でフィルタ (analyzer 有効時のみ有効) |
+| `tag` | - | タグ名でフィルタ (analyzer 有効時のみ有効) |
 | `sort` | `desc` | 昇順 / 降順 (`asc` / `desc`) |
 | `sort_by` | `bookmarked_at` | ソートキー (`bookmarked_at` / `created_at`) |
 
-`sort_by=created_at` は Snowflake ID の数値比較で実装されている。
+`sort_by=created_at` は Snowflake ID の数値比較で実装されている。`category` / `tag` フィルタは対応するテーブルが存在しない場合 (analyzer 未使用時) は無視される。
 
 ## crawler の API エンドポイント
 
@@ -325,6 +372,31 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 | GET | `/health` | ヘルスチェック (`{status: 'ok', timestamp}`) |
 | POST | `/crawl` | クロールを手動実行 (409 = 実行中、202 = 開始) |
 | GET | `/crawl/status` | 最新クロールジョブの状態 |
+| POST | `/bookmarks` | ブックマークを追加 (ボディ: `{account, tweetId}`)。Twitter API 経由でツイートを取得し DB に保存 |
+| DELETE | `/bookmarks/:tweetId` | ブックマークを削除 (クエリ: `?account=<username>`)。DB からも即時削除 |
+
+## analyzer（任意機能）
+
+`ANALYZER_URL` が設定され、Docker Compose の `analyzer` プロファイルで起動した場合のみ動作する。kuromoji による日本語形態素解析でツイート本文から名詞タグを抽出し、カテゴリキーワードとの照合でカテゴリを自動付与する。crawler・viewer と同じ `data/db.sqlite` を共有する。
+
+### 主要モジュール
+
+- `core/tagger.ts` — kuromoji トークナイザを初期化し、本文から名詞タグを抽出。品詞詳細のホワイトリスト (`一般`・`固有名詞`・`サ変接続`・`ナイ形容詞語幹`) で絞り込み、英語ストップワードを除外する。
+- `core/categorizer.ts` — 抽出タグとカテゴリキーワードを照合。confidence = マッチしたキーワード数 / 総キーワード数 (最小 0.1)。
+- `infra/database.ts` — タグ・カテゴリの永続化、IDF ベースのノイズタグ一括削除。
+
+### API エンドポイント
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/health` | ヘルスチェック |
+| POST | `/analyze` | 本文を解析しタグ・カテゴリを返す (ボディ: `{text}`) |
+| POST | `/analyze/prune-noise` | IDF ベースのノイズタグを一括削除 (クエリ: `?threshold=0.25`) |
+| GET | `/categories` | カテゴリ一覧 |
+| POST | `/categories` | カテゴリ作成 |
+| PUT | `/categories/:id` | カテゴリ更新 |
+| DELETE | `/categories/:id` | カテゴリ削除 |
+| GET | `/tags` | タグ一覧 |
 
 ## viewer/frontend の状態管理
 
@@ -333,6 +405,8 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 | `useBookmarks` | ブックマーク一覧・ページネーション・検索・ソート設定 (ソート設定は localStorage 永続化) |
 | `useAccounts` | アカウント一覧 |
 | `useCrawlStatus` | クロール状態 (10 秒ポーリング)・手動実行 |
+| `useFeatures` | 機能フラグ (`GET /api/features`)。analyzer 有効時のみカテゴリ/タグ UI を表示 |
+| `useCategories` | カテゴリ一覧・作成・更新・削除 (analyzer 有効時のみ) |
 
 ソート設定のキー: `bookmark-sort-by`, `bookmark-sort-order`
 
@@ -354,6 +428,7 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 | `PROXY_PASSWORD` | - | プロキシ認証パスワード |
 | `TWITTER_AUTH_TOKEN_{USERNAME}` | - | アカウント個別の auth_token Cookie (ログイン省略) |
 | `TWITTER_CT0_{USERNAME}` | - | アカウント個別の ct0 Cookie (ログイン省略) |
+| `ANALYZER_URL` | - | analyzer サービスの URL。設定時、クロール完了後に自動分析 (`/analyze`) と IDF ノイズプルーニング (`/analyze/prune-noise`) を実行する |
 
 ### viewer/backend
 
@@ -363,6 +438,14 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 | `LOG_DIR` | `/data/logs` | ログディレクトリ |
 | `VIEWER_PORT` | `3000` | HTTP サーバーポート |
 | `CRAWLER_URL` | `http://crawler:3001` | crawler サービスの URL |
+| `ANALYZER_URL` | - | analyzer サービスの URL。設定時に `/api/features` が analyzer 有効を返し、`/api/categories`・`/api/tags` を analyzer へプロキシする |
+
+### analyzer（任意）
+
+| 変数名 | デフォルト | 説明 |
+|--------|-----------|------|
+| `DATA_DIR` | `/data` | SQLite DB (`db.sqlite`) の保存先 (crawler・viewer と共有) |
+| `ANALYZER_PORT` | `3002` | HTTP サーバーポート |
 
 ## Docker ビルド
 
@@ -377,7 +460,11 @@ Chrome 120 on Windows 10 の JA3 TLS フィンガープリントを使用。`cyc
 2. **backend-builder**: バックエンドの依存をインストールし、`dist/` を `public/` にコピー
 3. **runner**: バックエンドを起動。`public/` の静的ファイルも配信し、SPA フォールバックで `index.html` を返す
 
-両コンテナともタイムゾーンは `Asia/Tokyo` に設定されている。
+### analyzer（任意）
+
+`analyzer/Dockerfile` でビルドする。kuromoji の辞書を同梱し、`tsx src/main.ts` で起動する。Docker Compose では `analyzer` プロファイル指定時のみ起動する（`docker compose --profile analyzer up -d`）。
+
+各コンテナともタイムゾーンは `Asia/Tokyo` に設定されている。
 
 ## コーディング規約
 


### PR DESCRIPTION
AGENTS.md / GEMINI.md を削除し、CLAUDE.md と .github/copilot-instructions.md に一本化しました。

- copilot-instructions.md: GitHub Copilot のコードレビュー観点(SQLインジェクション対策、認証情報の取り扱い、エラーハンドリング、並行処理、外部サービス連携、ドキュメント整合性)に再構成
- CLAUDE.md: 既存内容に加え、analyzer サービス(形態素解析によるタグ抽出・カテゴリ自動分類)の記述を追加。既存コードに実装済みだが未文書化だった機能を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)