### PR TITLE
fix(lint): reorder conditions for unicorn/prefer-simple-condition-first

### DIFF
--- a/crawler/src/shared/retry.ts
+++ b/crawler/src/shared/retry.ts
@@ -74,7 +74,7 @@ export async function withRetry<T>(
       // レートリミット (429/403): リトライ回数を消費せずに待機してから再試行する
       // Twitter は 429 だけでなく 403 もレートリミットとして返すことがある
       // maxRateLimitRetries を超えた場合はエラーをスローして無限ループを防ぐ
-      if ((status === 429 || status === 403) && response) {
+      if (response && (status === 429 || status === 403)) {
         if (rateLimitRetries >= maxRateLimitRetries) {
           logger.error(
             `${operationName}: Rate limit retries exceeded (${maxRateLimitRetries}). Giving up.`

--- a/viewer/backend/src/infra/database.ts
+++ b/viewer/backend/src/infra/database.ts
@@ -302,7 +302,7 @@ export function getBookmarks(
     )
     bindValues.push(effectiveCategoryId)
   }
-  if (params.tag && tagsTableExists) {
+  if (tagsTableExists && params.tag) {
     conditions.push(
       'EXISTS (SELECT 1 FROM tweet_tags tt JOIN tags tg ON tt.tag_id = tg.id WHERE tt.tweet_id = t.tweet_id AND tg.name = ?)'
     )


### PR DESCRIPTION
## What

Reorders two pre-existing boolean conditions so the simple identifier check comes first, per `unicorn/prefer-simple-condition-first`:

- `crawler/src/shared/retry.ts`: `response && (status === 429 || status === 403)`
- `viewer/backend/src/infra/database.ts`: `tagsTableExists && params.tag`

## Why

`master`'s `Node CI` has been failing lint since #303 (the `pnpm` bump), because `@book000/eslint-config` now enables `unicorn/prefer-simple-condition-first`, which flags these two spots. This blocks any Renovate PR rebased on `master` from passing CI (e.g. #324, #322, #321, #320, #319, #318), even when the dependency bump itself is unrelated.

No behavior change — pure condition reordering.