### PR TITLE
fix: make pnpm Docker deploy artifacts self-contained

### DIFF
--- a/analyzer/Dockerfile
+++ b/analyzer/Dockerfile
@@ -25,8 +25,7 @@ RUN --mount=type=cache,id=pnpm-analyzer,target=/pnpm/store pnpm install --offlin
 
 COPY analyzer/ ./analyzer/
 
-# pnpm v11 以降では inject-workspace-packages がロックファイルに記録されなくなったため --legacy フラグが必要
-RUN pnpm --filter twitter-bookmark-hub-analyzer deploy --legacy /deploy
+RUN pnpm --filter twitter-bookmark-hub-analyzer deploy /deploy
 
 # ---- Stage 2: ランタイム ----
 FROM node:24-alpine AS runner
@@ -42,5 +41,8 @@ ENV DATA_DIR=/data \
     ANALYZER_PORT=3002
 
 COPY --from=builder /deploy .
+
+# 最終イメージで workspace 依存が解決できることをビルド時に検証
+RUN node_modules/.bin/tsx -e "import('@twitter-bookmark-hub/shared').then(() => console.log('shared import ok'))"
 
 CMD ["node_modules/.bin/tsx", "src/main.ts"]

--- a/crawler/Dockerfile
+++ b/crawler/Dockerfile
@@ -36,8 +36,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 COPY crawler/ ./crawler/
 
 # devDependencies を除いた本番環境用スタンドアローンパッケージを作成する
-# pnpm v11 以降では inject-workspace-packages がロックファイルに記録されなくなったため --legacy フラグが必要
-RUN pnpm --filter twitter-bookmark-hub-crawler deploy --legacy /deploy
+RUN pnpm --filter twitter-bookmark-hub-crawler deploy /deploy
 
 # ---- Stage 2: ランタイム ----
 FROM node:24-alpine AS runner
@@ -58,5 +57,8 @@ ENV DATA_DIR=/data \
 
 # builder ステージで作成したスタンドアローンパッケージをコピー
 COPY --from=builder /deploy .
+
+# 最終イメージで workspace 依存が解決できることをビルド時に検証
+RUN node_modules/.bin/tsx -e "import('@twitter-bookmark-hub/shared').then(() => console.log('shared import ok'))"
 
 CMD ["node_modules/.bin/tsx", "src/main.ts"]

--- a/package.json
+++ b/package.json
@@ -1,9 +1,4 @@
 {
   "private": true,
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@11.20.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - viewer/backend
   - viewer/frontend
   - analyzer
+injectWorkspacePackages: true
 allowBuilds:
   better-sqlite3: true
   esbuild: true

--- a/viewer/Dockerfile
+++ b/viewer/Dockerfile
@@ -78,8 +78,7 @@ COPY viewer/backend/ ./viewer/backend/
 COPY --from=frontend-builder /app/viewer/frontend/dist ./viewer/backend/public
 
 # devDependencies を除いた本番環境用スタンドアローンパッケージを作成する
-# pnpm v11 以降では inject-workspace-packages がロックファイルに記録されなくなったため --legacy フラグが必要
-RUN pnpm --filter twitter-bookmark-hub-backend deploy --legacy /deploy
+RUN pnpm --filter twitter-bookmark-hub-backend deploy /deploy
 
 # ---- Stage 3: ランタイム ----
 FROM node:24-alpine AS runner
@@ -99,5 +98,8 @@ ENV DATA_DIR=/data \
 
 # backend-builder ステージで作成したスタンドアローンパッケージをコピー
 COPY --from=backend-builder /deploy .
+
+# 最終イメージで workspace 依存が解決できることをビルド時に検証
+RUN node_modules/.bin/tsx -e "import('@twitter-bookmark-hub/shared').then(() => console.log('shared import ok'))"
 
 CMD ["node_modules/.bin/tsx", "src/main.ts"]


### PR DESCRIPTION
## Summary

- pin the workspace root to `pnpm@11.20.0` so Docker builds do not depend on Corepack's moving default
- enable `injectWorkspacePackages` and regenerate the lockfile
- switch crawler, viewer, and analyzer from `pnpm deploy --legacy` to modern `pnpm deploy`
- add a final-runner build assertion that imports `@twitter-bookmark-hub/shared`, preventing publication of an image with a dangling workspace symlink
- remove the obsolete root `pnpm.onlyBuiltDependencies` block; build permissions already live in `pnpm-workspace.yaml`

## Root cause

The Dockerfiles invoked pnpm from the workspace root without a root `packageManager`, so the effective pnpm version could change without a repository change. During reproduction on the pre-fix tree, Corepack selected pnpm 11.21.0. Combined with `pnpm deploy --legacy`, the deploy artifact contained `node_modules/@twitter-bookmark-hub/shared` as a dangling link to `/app/shared`, which is not copied into the runner image.

The new final-stage import assertion reproduces the failure before the fix with `ERR_MODULE_NOT_FOUND` and passes after switching to modern deploy.

## Verification

- `corepack pnpm install --frozen-lockfile` — pnpm 11.20.0, success
- `corepack pnpm -r lint` — all workspaces pass
- crawler Docker build — success
- viewer Docker build — success
- analyzer Docker build — success
- final crawler/viewer/analyzer images — `@twitter-bookmark-hub/shared` exists and imports successfully through `tsx`
- analyzer runtime smoke test — database initialized, tokenizer ready, HTTP server reached startup on port 3002 and remained running during the check
